### PR TITLE
Fixing marko4 bug for dynamic tag

### DIFF
--- a/src/components/micro-frame/index.marko
+++ b/src/components/micro-frame/index.marko
@@ -1,8 +1,8 @@
-import component from "./component";
+import streamedComponent from "./component";
 
 // We have a proxy to the top level component
 // so that we can swap it out using `package.json#browser`.
 // https://gist.github.com/defunctzombie/4339901/49493836fb873ddaa4b8a7aa0ef2352119f69211
 // This allows us to have entirely different streaming implementations
 // depending on if this component is used in the server or browser.
-<${component} ...input/>
+<${streamedComponent} ...input/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail.  Include the package name if applicable. -->
Currently apps consuming the library and using **marko 4** are getting the following error:

<img width="460" alt="Screen Shot 2021-11-19 at 11 58 05 AM" src="https://user-images.githubusercontent.com/1570177/142669525-7bd2404c-e603-43e7-aab1-d7845c5cde35.png">

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
There is a conflict name with the **component** variable used by marko and the variable used as the dynamic tag
<img width="848" alt="Screen Shot 2021-11-19 at 12 01 32 PM" src="https://user-images.githubusercontent.com/1570177/142670082-b1f87f7f-6b58-4c52-9557-eb25d2c7dfd6.png">

<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
