### PR TITLE
fix: issue not clearing old content

### DIFF
--- a/src/components/micro-frame/component/web.marko
+++ b/src/components/micro-frame/component/web.marko
@@ -1,9 +1,16 @@
-<div>
-  <${state.err ? input.catch : state.loading ? input.loading : () => {}}(state.err)/>
+static function noop() {}
 
+<div>
+  <${
+    state.err
+      ? input.catch || noop
+      : state.loading
+      ? input.loading || noop
+      : noop
+  }(state.err)/>
   <!--
   We put the streamed html in a preserved fragment.
   This allows Marko to avoid diffing that section.
   -->
-  $ out.bf("@_", component, !state.err).ef();
+  $ out.bf("@_", component, !state.err && component.src === input.src).ef();
 </div>


### PR DESCRIPTION
## Description

Fixes an issue where when swapping the `src` it would not clear the old content away.


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
