### PR TITLE
feat: support client ordering timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,26 @@ and fallback to the network otherwise
 <micro-frame src="..." cache="force-cache"/>
 ```
 
+## `fetch`
+
+Optionally provide function to override default `fetch` logic.
+
+```marko
+<micro-frame src="..." name="..." fetch(url, options, fetch) {
+  // The 3rd parameter allows us to continue to use micro-frames fetch implementation (which is different server/browser).
+  // We can use this override to do things like a POST request, eg:
+  return fetch(url, {
+    ...options,
+    method: "POST",
+    headers: {
+      ...headers,
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({ "some": "json" })
+  });
+}  />
+```
+
 ## `timeout`
 
 A timeout in `ms` (defaults to 30s) that will prematurely abort the request. This will trigger the `<@catch>` if provided.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2430,14 +2430,21 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001271",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001271.tgz",
-      "integrity": "sha512-BBruZFWmt3HFdVPS8kceTBIguKxu4f99n5JNp06OlPD/luoAMIaIK5ieV5YjnBLH3Nysai9sxj9rpJj4ZisXOA==",
+      "version": "1.0.30001416",
+      "resolved": "https://npm.corp.ebay.com/caniuse-lite/-/caniuse-lite-1.0.30001416.tgz",
+      "integrity": "sha1-KWkq+KahFBLy08+aWdWI/N0hzkw=",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/cardinal": {
       "version": "2.1.1",
@@ -14943,9 +14950,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001271",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001271.tgz",
-      "integrity": "sha512-BBruZFWmt3HFdVPS8kceTBIguKxu4f99n5JNp06OlPD/luoAMIaIK5ieV5YjnBLH3Nysai9sxj9rpJj4ZisXOA==",
+      "version": "1.0.30001416",
+      "resolved": "https://npm.corp.ebay.com/caniuse-lite/-/caniuse-lite-1.0.30001416.tgz",
+      "integrity": "sha1-KWkq+KahFBLy08+aWdWI/N0hzkw=",
       "dev": true
     },
     "cardinal": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2430,21 +2430,14 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001416",
-      "resolved": "https://npm.corp.ebay.com/caniuse-lite/-/caniuse-lite-1.0.30001416.tgz",
-      "integrity": "sha1-KWkq+KahFBLy08+aWdWI/N0hzkw=",
+      "version": "1.0.30001271",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001271.tgz",
+      "integrity": "sha512-BBruZFWmt3HFdVPS8kceTBIguKxu4f99n5JNp06OlPD/luoAMIaIK5ieV5YjnBLH3Nysai9sxj9rpJj4ZisXOA==",
       "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-        }
-      ],
-      "license": "CC-BY-4.0"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
     },
     "node_modules/cardinal": {
       "version": "2.1.1",
@@ -14950,9 +14943,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001416",
-      "resolved": "https://npm.corp.ebay.com/caniuse-lite/-/caniuse-lite-1.0.30001416.tgz",
-      "integrity": "sha1-KWkq+KahFBLy08+aWdWI/N0hzkw=",
+      "version": "1.0.30001271",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001271.tgz",
+      "integrity": "sha512-BBruZFWmt3HFdVPS8kceTBIguKxu4f99n5JNp06OlPD/luoAMIaIK5ieV5YjnBLH3Nysai9sxj9rpJj4ZisXOA==",
       "dev": true
     },
     "cardinal": {

--- a/src/components/micro-frame-slot/component/node.marko
+++ b/src/components/micro-frame-slot/component/node.marko
@@ -1,4 +1,7 @@
-import StreamSource, { STREAM_SOURCE_MAP } from "../../stream-source/component/StreamSource";
+import StreamSource, {
+  STREAM_SOURCE_MAP,
+} from "../../stream-source/component/StreamSource";
+
 $ const sourceName = input.from;
 $ let err;
 $ {
@@ -13,17 +16,33 @@ $ {
 <else>
   $ const streamSource = STREAM_SOURCE_MAP.get(sourceName);
   $ const stream = streamSource.slot(input.slot);
+  $ let clientReorder = input.clientReorder;
   $ let finishLoading;
+  $ let clientOrderTimeoutPromise;
   $ {
     const loadingPromise =
       input.loading && new Promise((res) => (finishLoading = res));
   }
+  $ if (input.clientOrderTimeout) {
+    clientOrderTimeoutPromise = new Promise((resolve) => {
+      setTimeout(() => {
+        clientReorder = true;
+        resolve({
+          value: "",
+          done: false,
+        });
+      }, input.clientOrderTimeout);
+    });
+  }
   <div id=component.id data-slot=input.slot data-from=input.from>
     <macro name="wait">
-      <await(stream.next())
-        client-reorder=input.clientReorder
-        timeout=input.timeout
-      >
+      <await(
+        clientReorder
+          ? stream.next()
+          : Promise.race(
+              [clientOrderTimeoutPromise, stream.next()].filter(Boolean)
+            ),
+      ) client-reorder=clientReorder timeout=input.timeout>
         <@then|{ value, done }|>
           <if(!done)>
             $!{value}

--- a/src/components/micro-frame-slot/component/node.marko
+++ b/src/components/micro-frame-slot/component/node.marko
@@ -37,11 +37,9 @@ $ {
   <div id=component.id data-slot=input.slot data-from=input.from>
     <macro name="wait">
       <await(
-        clientReorder
-          ? stream.next()
-          : Promise.race(
-              [clientOrderTimeoutPromise, stream.next()].filter(Boolean)
-            ),
+        clientOrderTimeoutPromise && !clientReorder
+          ? Promise.race([clientOrderTimeoutPromise, stream.next()])
+          : stream.next(),
       ) client-reorder=clientReorder timeout=input.timeout>
         <@then|{ value, done }|>
           <if(!done)>

--- a/src/components/micro-frame-slot/marko-tag.json
+++ b/src/components/micro-frame-slot/marko-tag.json
@@ -25,6 +25,22 @@
       }
     ]
   },
+  "@timeout": {
+    "type": "number",
+    "autocomplete": [
+      {
+        "description": "An idle timeout in ms after which the request is ended (default 30 seconds)"
+      }
+    ]
+  },
+  "@client-order-timeout": {
+    "type": "number",
+    "autocomplete": [
+      {
+        "description": "An idle timeout in ms after which the rendering will convert to client-reorder"
+      }
+    ]
+  },
   "@catch <catch>": {
     "attributes": {},
     "autocomplete": [

--- a/src/components/micro-frame-sse/README.md
+++ b/src/components/micro-frame-sse/README.md
@@ -179,6 +179,23 @@ Flag indicate if the slot need to be streamed out-of-order. Please refer to [cli
 <micro-frame-slot from="..." slot="..." client-reorder />
 ```
 
+## `client-order-timeout`
+
+A timeout in `ms` that will prematurely convert slot rendering to out-of-order (aka `client-reorder = true`).
+
+```marko
+<micro-frame-slot src="..." name="..." client-order-timeout=1000/>
+```
+
+## `timeout` in slot
+
+A timeout in `ms` (defaults to 30s) that will prematurely abort the slot. This will trigger the `<@catch>` if provided.
+If set to `0` the request will not time out.
+
+```marko
+<micro-frame-slot src="..." name="..." timeout=0/>
+```
+
 ## `<@catch|err|>`
 
 An [attribute tag](https://markojs.com/docs/syntax/#attribute-tag) rendered when there is a network error or timeout.

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-order-timeout/renders.expected/loading.0.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-order-timeout/renders.expected/loading.0.html
@@ -13,18 +13,4 @@
   data-from="test"
   data-slot="slot_1"
   id="GENERATED-2"
->
-  <noscript
-    id="GENERATED-3"
-  />
-</div>
-<div
-  data-from="test"
-  data-slot="slot_2"
-  id="GENERATED-4"
->
-  <noscript
-    id="GENERATED-5"
-  />
-</div>
-non-reorder data
+/>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-order-timeout/renders.expected/loading.1.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-order-timeout/renders.expected/loading.1.html
@@ -14,17 +14,7 @@
   data-slot="slot_1"
   id="GENERATED-2"
 >
-  <noscript
-    id="GENERATED-3"
-  />
+  <p>
+    test_html for slot_1
+  </p>
 </div>
-<div
-  data-from="test"
-  data-slot="slot_2"
-  id="GENERATED-4"
->
-  <noscript
-    id="GENERATED-5"
-  />
-</div>
-non-reorder data

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-order-timeout/renders.expected/loading.2.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-order-timeout/renders.expected/loading.2.html
@@ -26,6 +26,9 @@
   data-slot="slot_2"
   id="GENERATED-4"
 >
+  <p>
+    test_html for slot_2
+  </p>
   <noscript
     id="GENERATED-5"
   />
@@ -34,11 +37,11 @@ non-reorder data
 <div
   id="GENERATED-6"
   style="display:none"
-/>
-<div
-  id="GENERATED-7"
-  style="display:none"
-/>
+>
+  <noscript
+    id="GENERATED-7"
+  />
+</div>
 <script>
-  function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b&lt;f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b&lt;f;b++)c(a[b])}};$af(0);$af(1)
+  function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b&lt;f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b&lt;f;b++)c(a[b])}};$af(0)
 </script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-order-timeout/renders.expected/loading.3.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-order-timeout/renders.expected/loading.3.html
@@ -26,6 +26,9 @@
   data-slot="slot_2"
   id="GENERATED-4"
 >
+  <p>
+    test_html for slot_2
+  </p>
   <noscript
     id="GENERATED-5"
   />
@@ -35,10 +38,6 @@ non-reorder data
   id="GENERATED-6"
   style="display:none"
 />
-<div
-  id="GENERATED-7"
-  style="display:none"
-/>
 <script>
-  function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b&lt;f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b&lt;f;b++)c(a[b])}};$af(0);$af(1)
+  function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b&lt;f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b&lt;f;b++)c(a[b])}};$af(0)
 </script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-order-timeout/renders.expected/loading.4.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-order-timeout/renders.expected/loading.4.html
@@ -38,41 +38,30 @@ non-reorder data
   id="GENERATED-6"
   style="display:none"
 />
+<script>
+  function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b&lt;f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b&lt;f;b++)c(a[b])}};$af(0)
+</script>
 <div
   id="GENERATED-7"
   style="display:none"
 />
-<script>
-  function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b&lt;f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b&lt;f;b++)c(a[b])}};$af(0);$af(1)
-</script>
 <div
   id="GENERATED-8"
-  style="display:none"
-/>
-<script>
-  $af(2)
-</script>
-<div
-  id="GENERATED-9"
-  style="display:none"
-/>
-<div
-  id="GENERATED-10"
   style="display:none"
 >
   next chunk for slot_1
   <noscript
-    id="GENERATED-11"
+    id="GENERATED-9"
   />
 </div>
 <div
-  id="GENERATED-12"
+  id="GENERATED-10"
   style="display:none"
 />
 <div
-  id="GENERATED-13"
+  id="GENERATED-11"
   style="display:none"
 />
 <script>
-  $af(3);$af(4);$af(5);$af(6)
+  $af(1);$af(2);$af(3);$af(4)
 </script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-order-timeout/renders.expected/loading.5.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-order-timeout/renders.expected/loading.5.html
@@ -1,0 +1,53 @@
+<div>
+  Host app
+</div>
+<div
+  data-src="embed"
+  id="GENERATED-0"
+/>
+<div
+  data-from="test"
+  data-slot="slot_1"
+  id="GENERATED-1"
+>
+  <p>
+    test_html for slot_1
+  </p>
+  next chunk for slot_1
+</div>
+<div
+  data-from="test"
+  data-slot="slot_2"
+  id="GENERATED-2"
+>
+  <p>
+    test_html for slot_2
+  </p>
+</div>
+non-reorder data
+<div
+  id="GENERATED-3"
+  style="display:none"
+/>
+<script>
+  function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b&lt;f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b&lt;f;b++)c(a[b])}};$af(0)
+</script>
+<div
+  id="GENERATED-4"
+  style="display:none"
+/>
+<div
+  id="GENERATED-5"
+  style="display:none"
+/>
+<div
+  id="GENERATED-6"
+  style="display:none"
+/>
+<div
+  id="GENERATED-7"
+  style="display:none"
+/>
+<script>
+  $af(1);$af(2);$af(3);$af(4)
+</script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-reorder-false/renders.expected/loading.0.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-reorder-false/renders.expected/loading.0.html
@@ -13,18 +13,4 @@
   data-from="test"
   data-slot="slot_1"
   id="GENERATED-2"
->
-  <noscript
-    id="GENERATED-3"
-  />
-</div>
-<div
-  data-from="test"
-  data-slot="slot_2"
-  id="GENERATED-4"
->
-  <noscript
-    id="GENERATED-5"
-  />
-</div>
-non-reorder data
+/>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-reorder-false/renders.expected/loading.1.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-reorder-false/renders.expected/loading.1.html
@@ -14,17 +14,7 @@
   data-slot="slot_1"
   id="GENERATED-2"
 >
-  <noscript
-    id="GENERATED-3"
-  />
+  <p>
+    test_html for slot_1
+  </p>
 </div>
-<div
-  data-from="test"
-  data-slot="slot_2"
-  id="GENERATED-4"
->
-  <noscript
-    id="GENERATED-5"
-  />
-</div>
-non-reorder data

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-reorder-false/renders.expected/loading.2.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-reorder-false/renders.expected/loading.2.html
@@ -17,26 +17,28 @@
   <p>
     test_html for slot_1
   </p>
-  <noscript
-    id="GENERATED-3"
-  />
+  next chunk for slot_1
 </div>
 <div
   data-from="test"
   data-slot="slot_2"
+  id="GENERATED-3"
+>
+  <p>
+    test_html for slot_2
+  </p>
+</div>
+non-reorder data
+<div
   id="GENERATED-4"
+  style="display:none"
 >
   <noscript
     id="GENERATED-5"
   />
 </div>
-non-reorder data
 <div
   id="GENERATED-6"
-  style="display:none"
-/>
-<div
-  id="GENERATED-7"
   style="display:none"
 />
 <script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-reorder-false/renders.expected/loading.3.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-reorder-false/renders.expected/loading.3.html
@@ -4,75 +4,35 @@
 <div
   data-src="embed"
   id="GENERATED-0"
->
-  <noscript
-    id="GENERATED-1"
-  />
-</div>
+/>
 <div
   data-from="test"
   data-slot="slot_1"
-  id="GENERATED-2"
+  id="GENERATED-1"
 >
   <p>
     test_html for slot_1
   </p>
-  <noscript
-    id="GENERATED-3"
-  />
+  next chunk for slot_1
 </div>
 <div
   data-from="test"
   data-slot="slot_2"
-  id="GENERATED-4"
+  id="GENERATED-2"
 >
   <p>
     test_html for slot_2
   </p>
-  <noscript
-    id="GENERATED-5"
-  />
 </div>
 non-reorder data
 <div
-  id="GENERATED-6"
+  id="GENERATED-3"
   style="display:none"
 />
 <div
-  id="GENERATED-7"
+  id="GENERATED-4"
   style="display:none"
 />
 <script>
   function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b&lt;f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b&lt;f;b++)c(a[b])}};$af(0);$af(1)
-</script>
-<div
-  id="GENERATED-8"
-  style="display:none"
-/>
-<script>
-  $af(2)
-</script>
-<div
-  id="GENERATED-9"
-  style="display:none"
-/>
-<div
-  id="GENERATED-10"
-  style="display:none"
->
-  next chunk for slot_1
-  <noscript
-    id="GENERATED-11"
-  />
-</div>
-<div
-  id="GENERATED-12"
-  style="display:none"
-/>
-<div
-  id="GENERATED-13"
-  style="display:none"
-/>
-<script>
-  $af(3);$af(4);$af(5);$af(6)
 </script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-reorder/renders.expected/loading.2.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-reorder/renders.expected/loading.2.html
@@ -14,9 +14,6 @@
   data-slot="slot_1"
   id="GENERATED-2"
 >
-  <p>
-    test_html for slot_1
-  </p>
   <noscript
     id="GENERATED-3"
   />
@@ -30,14 +27,26 @@
     id="GENERATED-5"
   />
 </div>
+non-reorder data
 <div
   id="GENERATED-6"
   style="display:none"
-/>
+>
+  <noscript
+    id="GENERATED-7"
+  />
+</div>
 <div
-  id="GENERATED-7"
+  id="GENERATED-8"
   style="display:none"
-/>
+>
+  <p>
+    test_html for slot_1
+  </p>
+  <noscript
+    id="GENERATED-9"
+  />
+</div>
 <script>
   function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b&lt;f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b&lt;f;b++)c(a[b])}};$af(0);$af(1)
 </script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-reorder/renders.expected/loading.4.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-reorder/renders.expected/loading.4.html
@@ -26,13 +26,11 @@
   data-slot="slot_2"
   id="GENERATED-4"
 >
-  <p>
-    test_html for slot_2
-  </p>
   <noscript
     id="GENERATED-5"
   />
 </div>
+non-reorder data
 <div
   id="GENERATED-6"
   style="display:none"
@@ -47,7 +45,14 @@
 <div
   id="GENERATED-8"
   style="display:none"
-/>
+>
+  <p>
+    test_html for slot_2
+  </p>
+  <noscript
+    id="GENERATED-9"
+  />
+</div>
 <script>
   $af(2)
 </script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-reorder/renders.expected/loading.5.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-reorder/renders.expected/loading.5.html
@@ -33,6 +33,7 @@
     id="GENERATED-5"
   />
 </div>
+non-reorder data
 <div
   id="GENERATED-6"
   style="display:none"
@@ -50,28 +51,4 @@
 />
 <script>
   $af(2)
-</script>
-<div
-  id="GENERATED-9"
-  style="display:none"
-/>
-<div
-  id="GENERATED-10"
-  style="display:none"
->
-  next chunk for slot_1
-  <noscript
-    id="GENERATED-11"
-  />
-</div>
-<div
-  id="GENERATED-12"
-  style="display:none"
-/>
-<div
-  id="GENERATED-13"
-  style="display:none"
-/>
-<script>
-  $af(3);$af(4);$af(5);$af(6)
 </script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-reorder/renders.expected/loading.7.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-reorder/renders.expected/loading.7.html
@@ -4,36 +4,45 @@
 <div
   data-src="embed"
   id="GENERATED-0"
->
-  <noscript
-    id="GENERATED-1"
-  />
-</div>
+/>
 <div
   data-from="test"
   data-slot="slot_1"
-  id="GENERATED-2"
+  id="GENERATED-1"
 >
   <p>
     test_html for slot_1
   </p>
-  <noscript
-    id="GENERATED-3"
-  />
+  next chunk for slot_1
 </div>
 <div
   data-from="test"
   data-slot="slot_2"
-  id="GENERATED-4"
+  id="GENERATED-2"
 >
   <p>
     test_html for slot_2
   </p>
-  <noscript
-    id="GENERATED-5"
-  />
 </div>
 non-reorder data
+<div
+  id="GENERATED-3"
+  style="display:none"
+/>
+<div
+  id="GENERATED-4"
+  style="display:none"
+/>
+<script>
+  function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b&lt;f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b&lt;f;b++)c(a[b])}};$af(0);$af(1)
+</script>
+<div
+  id="GENERATED-5"
+  style="display:none"
+/>
+<script>
+  $af(2)
+</script>
 <div
   id="GENERATED-6"
   style="display:none"
@@ -42,35 +51,12 @@ non-reorder data
   id="GENERATED-7"
   style="display:none"
 />
-<script>
-  function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b&lt;f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b&lt;f;b++)c(a[b])}};$af(0);$af(1)
-</script>
 <div
   id="GENERATED-8"
   style="display:none"
 />
-<script>
-  $af(2)
-</script>
 <div
   id="GENERATED-9"
-  style="display:none"
-/>
-<div
-  id="GENERATED-10"
-  style="display:none"
->
-  next chunk for slot_1
-  <noscript
-    id="GENERATED-11"
-  />
-</div>
-<div
-  id="GENERATED-12"
-  style="display:none"
-/>
-<div
-  id="GENERATED-13"
   style="display:none"
 />
 <script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-timeout/renders.expected/loading.0.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-timeout/renders.expected/loading.0.html
@@ -13,18 +13,4 @@
   data-from="test"
   data-slot="slot_1"
   id="GENERATED-2"
->
-  <noscript
-    id="GENERATED-3"
-  />
-</div>
-<div
-  data-from="test"
-  data-slot="slot_2"
-  id="GENERATED-4"
->
-  <noscript
-    id="GENERATED-5"
-  />
-</div>
-non-reorder data
+/>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-timeout/renders.expected/loading.1.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-timeout/renders.expected/loading.1.html
@@ -14,17 +14,7 @@
   data-slot="slot_1"
   id="GENERATED-2"
 >
-  <noscript
-    id="GENERATED-3"
-  />
+  <p>
+    test_html for slot_1
+  </p>
 </div>
-<div
-  data-from="test"
-  data-slot="slot_2"
-  id="GENERATED-4"
->
-  <noscript
-    id="GENERATED-5"
-  />
-</div>
-non-reorder data

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-timeout/renders.expected/loading.2.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-timeout/renders.expected/loading.2.html
@@ -14,17 +14,16 @@
   data-slot="slot_1"
   id="GENERATED-2"
 >
-  <noscript
-    id="GENERATED-3"
-  />
+  <p>
+    test_html for slot_1
+  </p>
 </div>
 <div
   data-from="test"
   data-slot="slot_2"
-  id="GENERATED-4"
+  id="GENERATED-3"
 >
-  <noscript
-    id="GENERATED-5"
-  />
+  <p>
+    test_html for slot_2
+  </p>
 </div>
-non-reorder data

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-timeout/renders.expected/loading.3.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-timeout/renders.expected/loading.3.html
@@ -17,26 +17,26 @@
   <p>
     test_html for slot_1
   </p>
-  <noscript
-    id="GENERATED-3"
-  />
 </div>
 <div
   data-from="test"
   data-slot="slot_2"
+  id="GENERATED-3"
+>
+  <p>
+    test_html for slot_2
+  </p>
+</div>
+<div
   id="GENERATED-4"
+  style="display:none"
 >
   <noscript
     id="GENERATED-5"
   />
 </div>
-non-reorder data
 <div
   id="GENERATED-6"
-  style="display:none"
-/>
-<div
-  id="GENERATED-7"
   style="display:none"
 />
 <script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-timeout/renders.expected/loading.4.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-timeout/renders.expected/loading.4.html
@@ -4,75 +4,33 @@
 <div
   data-src="embed"
   id="GENERATED-0"
->
-  <noscript
-    id="GENERATED-1"
-  />
-</div>
+/>
 <div
   data-from="test"
   data-slot="slot_1"
-  id="GENERATED-2"
+  id="GENERATED-1"
 >
   <p>
     test_html for slot_1
   </p>
-  <noscript
-    id="GENERATED-3"
-  />
 </div>
 <div
   data-from="test"
   data-slot="slot_2"
-  id="GENERATED-4"
+  id="GENERATED-2"
 >
   <p>
     test_html for slot_2
   </p>
-  <noscript
-    id="GENERATED-5"
-  />
 </div>
-non-reorder data
 <div
-  id="GENERATED-6"
+  id="GENERATED-3"
   style="display:none"
 />
 <div
-  id="GENERATED-7"
+  id="GENERATED-4"
   style="display:none"
 />
 <script>
   function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b&lt;f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b&lt;f;b++)c(a[b])}};$af(0);$af(1)
-</script>
-<div
-  id="GENERATED-8"
-  style="display:none"
-/>
-<script>
-  $af(2)
-</script>
-<div
-  id="GENERATED-9"
-  style="display:none"
-/>
-<div
-  id="GENERATED-10"
-  style="display:none"
->
-  next chunk for slot_1
-  <noscript
-    id="GENERATED-11"
-  />
-</div>
-<div
-  id="GENERATED-12"
-  style="display:none"
-/>
-<div
-  id="GENERATED-13"
-  style="display:none"
-/>
-<script>
-  $af(3);$af(4);$af(5);$af(6)
 </script>

--- a/src/components/micro-frame-sse/__tests__/fixtures/ssr-client-order-timeout/embed.marko
+++ b/src/components/micro-frame-sse/__tests__/fixtures/ssr-client-order-timeout/embed.marko
@@ -1,0 +1,25 @@
+import { wait } from "../../../../../__tests__/queue";
+import fs from "fs";
+import path from "path";
+
+$ const slot_1_html = fs.readFileSync(path.resolve(__dirname ,'slot_1.html'), 'utf8');
+$ const slot_2_html = fs.readFileSync(path.resolve(__dirname ,'slot_2.html'), 'utf8');
+$ const first = `id: slot_1\ndata: ${slot_1_html.replace(/\r?\n/g, '')}\n\n`;
+$ const second = `id: slot_2\ndata: ${slot_2_html.replace(/\r?\n/g, '')}\n\n`;
+$ const third = `id: slot_1\ntype: update\ndata: next chunk for slot_1`;
+
+<await(wait())>
+  <@then>
+    $!{first}
+    <await(wait())>
+      <@then>
+        $!{second}
+        <await(new Promise(res => setTimeout(res, 2000)))>
+          <@then>
+            $!{third}
+          </@then>
+        </await>
+      </@then>
+    </await>
+  </@then>
+</await>

--- a/src/components/micro-frame-sse/__tests__/fixtures/ssr-client-order-timeout/index.marko
+++ b/src/components/micro-frame-sse/__tests__/fixtures/ssr-client-order-timeout/index.marko
@@ -9,8 +9,8 @@
 <body>
   <div>Host app</div>
 <micro-frame-sse src="embed" name="test" read=(e => [e.lastEventId, e.data]) />
-<micro-frame-slot from="test" slot="slot_1" client-reorder />
-<micro-frame-slot from="test" slot="slot_2" client-reorder />
+<micro-frame-slot from="test" slot="slot_1" client-order-timeout=1000 />
+<micro-frame-slot from="test" slot="slot_2" client-order-timeout=1000 />
 <await(new Promise(res => setTimeout(() => res('non-reorder data'))))>
   <@then|result|>
     ${result}

--- a/src/components/micro-frame-sse/__tests__/fixtures/ssr-client-order-timeout/slot_1.html
+++ b/src/components/micro-frame-sse/__tests__/fixtures/ssr-client-order-timeout/slot_1.html
@@ -1,0 +1,1 @@
+<p>test_html for slot_1</p>

--- a/src/components/micro-frame-sse/__tests__/fixtures/ssr-client-order-timeout/slot_2.html
+++ b/src/components/micro-frame-sse/__tests__/fixtures/ssr-client-order-timeout/slot_2.html
@@ -1,0 +1,1 @@
+<p>test_html for slot_2</p>

--- a/src/components/micro-frame-sse/__tests__/fixtures/ssr-client-reorder-false/embed.marko
+++ b/src/components/micro-frame-sse/__tests__/fixtures/ssr-client-reorder-false/embed.marko
@@ -1,0 +1,25 @@
+import { wait } from "../../../../../__tests__/queue";
+import fs from "fs";
+import path from "path";
+
+$ const slot_1_html = fs.readFileSync(path.resolve(__dirname ,'slot_1.html'), 'utf8');
+$ const slot_2_html = fs.readFileSync(path.resolve(__dirname ,'slot_2.html'), 'utf8');
+$ const first = `id: slot_1\ndata: ${slot_1_html.replace(/\r?\n/g, '')}\n\n`;
+$ const second = `id: slot_2\ndata: ${slot_2_html.replace(/\r?\n/g, '')}\n\n`;
+$ const third = `id: slot_1\ntype: update\ndata: next chunk for slot_1`;
+
+<await(wait())>
+  <@then>
+    $!{first}
+    <await(wait())>
+      <@then>
+        $!{second}
+        <await(wait())>
+          <@then>
+            $!{third}
+          </@then>
+        </await>
+      </@then>
+    </await>
+  </@then>
+</await>

--- a/src/components/micro-frame-sse/__tests__/fixtures/ssr-client-reorder-false/index.marko
+++ b/src/components/micro-frame-sse/__tests__/fixtures/ssr-client-reorder-false/index.marko
@@ -9,8 +9,8 @@
 <body>
   <div>Host app</div>
 <micro-frame-sse src="embed" name="test" read=(e => [e.lastEventId, e.data]) />
-<micro-frame-slot from="test" slot="slot_1" client-reorder />
-<micro-frame-slot from="test" slot="slot_2" client-reorder />
+<micro-frame-slot from="test" slot="slot_1" />
+<micro-frame-slot from="test" slot="slot_2" />
 <await(new Promise(res => setTimeout(() => res('non-reorder data'))))>
   <@then|result|>
     ${result}

--- a/src/components/micro-frame-sse/__tests__/fixtures/ssr-client-reorder-false/slot_1.html
+++ b/src/components/micro-frame-sse/__tests__/fixtures/ssr-client-reorder-false/slot_1.html
@@ -1,0 +1,1 @@
+<p>test_html for slot_1</p>

--- a/src/components/micro-frame-sse/__tests__/fixtures/ssr-client-reorder-false/slot_2.html
+++ b/src/components/micro-frame-sse/__tests__/fixtures/ssr-client-reorder-false/slot_2.html
@@ -1,0 +1,1 @@
+<p>test_html for slot_2</p>

--- a/src/components/micro-frame-sse/__tests__/fixtures/ssr-timeout/embed.marko
+++ b/src/components/micro-frame-sse/__tests__/fixtures/ssr-timeout/embed.marko
@@ -1,0 +1,25 @@
+import { wait } from "../../../../../__tests__/queue";
+import fs from "fs";
+import path from "path";
+
+$ const slot_1_html = fs.readFileSync(path.resolve(__dirname ,'slot_1.html'), 'utf8');
+$ const slot_2_html = fs.readFileSync(path.resolve(__dirname ,'slot_2.html'), 'utf8');
+$ const first = `id: slot_1\ndata: ${slot_1_html.replace(/\r?\n/g, '')}\n\n`;
+$ const second = `id: slot_2\ndata: ${slot_2_html.replace(/\r?\n/g, '')}\n\n`;
+$ const third = `id: slot_1\ntype: update\ndata: next chunk for slot_1`;
+
+<await(wait())>
+  <@then>
+    $!{first}
+    <await(wait())>
+      <@then>
+        $!{second}
+        <await(new Promise(res => setTimeout(res, 2000)))>
+          <@then>
+            $!{third}
+          </@then>
+        </await>
+      </@then>
+    </await>
+  </@then>
+</await>

--- a/src/components/micro-frame-sse/__tests__/fixtures/ssr-timeout/index.marko
+++ b/src/components/micro-frame-sse/__tests__/fixtures/ssr-timeout/index.marko
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Simple Example</title>
+  <esbuild-assets/>
+</head>
+<body>
+  <div>Host app</div>
+  <micro-frame-sse src="embed" name="test" read=(e => [e.lastEventId, e.data]) />
+  <micro-frame-slot from="test" slot="slot_1" timeout=1000 />
+  <micro-frame-slot from="test" slot="slot_2" />
+</body>
+</html>

--- a/src/components/micro-frame-sse/__tests__/fixtures/ssr-timeout/slot_1.html
+++ b/src/components/micro-frame-sse/__tests__/fixtures/ssr-timeout/slot_1.html
@@ -1,0 +1,1 @@
+<p>test_html for slot_1</p>

--- a/src/components/micro-frame-sse/__tests__/fixtures/ssr-timeout/slot_2.html
+++ b/src/components/micro-frame-sse/__tests__/fixtures/ssr-timeout/slot_2.html
@@ -1,0 +1,1 @@
+<p>test_html for slot_2</p>

--- a/src/components/micro-frame-sse/__tests__/server.test.ts
+++ b/src/components/micro-frame-sse/__tests__/server.test.ts
@@ -186,4 +186,19 @@ describe("micro-frame-sse", () => {
     "ssr client-reorder",
     fixture(path.join(__dirname, "fixtures/ssr-client-reorder"))
   );
+
+  describe(
+    "ssr client-reorder false",
+    fixture(path.join(__dirname, "fixtures/ssr-client-reorder-false"))
+  );
+
+  describe(
+    "ssr client-order-timeout",
+    fixture(path.join(__dirname, "fixtures/ssr-client-order-timeout"))
+  );
+
+  describe(
+    "ssr timeout",
+    fixture(path.join(__dirname, "fixtures/ssr-timeout"))
+  );
 });

--- a/src/components/micro-frame/component/node.marko
+++ b/src/components/micro-frame/component/node.marko
@@ -2,22 +2,9 @@ import path from "path";
 import fetch from "make-fetch-happen";
 
 static const cachePath = path.resolve("node_modules/.cache/fetch");
-static function createDeferredPromise() {
-  let resolve;
-  let reject;
-  const promise = new Promise((_resolve, _reject) => {
-    resolve = _resolve;
-    reject = _reject;
-  });
-  promise.resolve = resolve;
-  promise.reject = reject;
-  return promise;
-}
+static const strictSSL = process.env.NODE_TLS_REJECT_UNAUTHORIZED !== "0";
 
-$ let buf = "";
-$ let hasMore = true;
-$ let sentData = false;
-$ let next = (async () => {
+static async function fetchStream(input, out) {
   const incomingMessage = out.stream && (out.stream.req || out.stream.request);
 
   if (!incomingMessage) {
@@ -25,36 +12,31 @@ $ let next = (async () => {
   }
 
   const url = new URL(input.src, `${incomingMessage.protocol}://${incomingMessage.headers.host}`);
-  const res = await fetch(url, {
-    cachePath,
-    cache: input.cache,
-    strictSSL: process.env.NODE_TLS_REJECT_UNAUTHORIZED !== "0",
-    headers: {
-      ...incomingMessage.headers,
-      ...input.headers,
-      accept: "text/html",
-    }
-  });
+  const { cache } = input;
+  const headers = {
+    ...incomingMessage.headers,
+    ...input.headers,
+    accept: "text/html",
+  };
+
+  const res = await (input.fetch
+    ? input.fetch(url, { cache, headers }, fetch)
+    : fetch(url, {
+      cache,
+      headers,
+      cachePath,
+      strictSSL,
+    })
+  );
 
   if (!res.ok) throw new Error(res.statusText);
-  next = createDeferredPromise();
 
-  res.body
-    .on("data", data => {
-      buf += data.toString();
-      if (next) next = next.resolve();
-    })
-    .on("error", err => {
-      if (next) next = next.reject(err);
-      else out.error(err);
-    })
-    .on("end", () => {
-      hasMore = false;
-      if (next) next = next.resolve();
-    });
+  if (!res.body || !res.body[Symbol.asyncIterator]) {
+    throw new Error("Response body must be a stream.");
+  }
 
-    return next;
-})();
+  return res.body[Symbol.asyncIterator]();
+}
 
 <div id=component.id data-src=input.src>
   <if(input.loading)>
@@ -63,32 +45,42 @@ $ let next = (async () => {
     $!{`<!--${component.id}-->`}
   </if>
 
-  <macro name="wait">
-    <await(next)
-      timeout=input.timeout
-      catch=(!sentData && input.catch)>
-      <@then>
-        $!{buf}
-        <if(hasMore)>
-          $ buf = "";
-          $ sentData = true;
-          $ next = createDeferredPromise();
-          <wait/>
-        </if>
-      </@then>
-    </await>
-  </macro>
-
   <!--
   We put the streamed html in a preserved fragment.
   This allows Marko to avoid diffing that section.
   -->
   $ out.bf("@_", component, true);
-  <wait/>
-  $ out.ef();
+  <await(fetchStream(input, out)) timeout=input.timeout catch=input.catch>
+    <@then|iter|>
+      <macro name="wait">
+        <await(iter.next()) timeout=input.timeout>
+          <@then|{ value, done }|>
+            <if(done)>
+              <if(input.loading)>
+                <!-- Remove all of the <@loading> content after we've received all the data -->
+                $ out.script(`((e,t,d)=>{t=document.getElementById(e);do{t.removeChild(d=t.firstChild)}while(d.data!==e)})(${JSON.stringify(component.id)});`);
+              </if>
+            </if>
+            <else>
+              $!{value}
+              <wait/>
+            </else>
+          </@then>
+          <@catch|err|>
+            <if(input.catch)>
+              <!-- Remove everything in the container and render our catch handler -->
+              <script>document.getElementById(${JSON.stringify(component.id)}).textContent=""</script>
+              <${input.catch}(err)/>
+            </if>
+            <else>
+              $ throw err;
+            </else>
+          </@catch>
+        </await>
+      </macro>
 
-  <if(input.loading)>
-    <!-- Remove all of the <@loading> content after we've received all the data -->
-    $ out.script(`((e,t,d)=>{t=document.getElementById(e);do{t.removeChild(d=t.firstChild)}while(d.data!==e)})(${JSON.stringify(component.id)});`);
-  </if>
+      <wait/>
+    </@then>
+  </await>
+  $ out.ef();
 </div>

--- a/src/components/micro-frame/component/web.component.ts
+++ b/src/components/micro-frame/component/web.component.ts
@@ -7,6 +7,11 @@ interface Input {
   loading?: unknown;
   cache?: RequestCache;
   headers?: Record<string, string>;
+  fetch?: (
+    url: string,
+    options: RequestInit,
+    fetch: typeof window.fetch
+  ) => Promise<Response>;
 }
 
 interface State {
@@ -49,11 +54,15 @@ export = {
     let err: Error | undefined;
 
     try {
-      const res = await fetch(this.src, {
+      const options: RequestInit = {
         cache: this.input.cache,
         signal: controller.signal,
         headers: Object.assign({}, this.input.headers, { accept: "text/html" }),
-      });
+      };
+
+      const res = await (this.input.fetch
+        ? this.input.fetch(this.src, options, fetch)
+        : fetch(this.src, options));
       if (!res.ok) throw new Error(res.statusText);
       const reader = res.body!.getReader();
       const decoder = new TextDecoder();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Support client-order-timeout attribute to convert streaming slot to out-of-order after given time.

The PR also includes supporting `timeout` attribute for micro-frame-slot (missing in previous PRs) as well as some updated unit tests.

## Motivation and Context

In certain cases, a page wants to have content being rendered in-order within certain timeframe, after which the `await` tag should not stop further content to be rendered. The solution is to set a timeout for client-reorder so that it keeps ordering for given time then it will be rendered out-of-order.

<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
