### PR TITLE
fix: add back missing timeout attribute

### DIFF
--- a/src/components/micro-frame-slot/marko-tag.json
+++ b/src/components/micro-frame-slot/marko-tag.json
@@ -25,6 +25,14 @@
       }
     ]
   },
+  "@timeout": {
+    "type": "number",
+    "autocomplete": [
+      {
+        "description": "An idle timeout in ms after which the request is ended (default 30 seconds)"
+      }
+    ]
+  },
   "@catch <catch>": {
     "attributes": {},
     "autocomplete": [

--- a/src/components/micro-frame-sse/README.md
+++ b/src/components/micro-frame-sse/README.md
@@ -179,6 +179,15 @@ Flag indicate if the slot need to be streamed out-of-order. Please refer to [cli
 <micro-frame-slot from="..." slot="..." client-reorder />
 ```
 
+## `timeout` in slot
+
+A timeout in `ms` (defaults to 30s) that will prematurely abort the slot. This will trigger the `<@catch>` if provided.
+If set to `0` the request will not time out.
+
+```marko
+<micro-frame-slot src="..." name="..." timeout=0/>
+```
+
 ## `<@catch|err|>`
 
 An [attribute tag](https://markojs.com/docs/syntax/#attribute-tag) rendered when there is a network error or timeout.

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-reorder-false/renders.expected/loading.0.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-reorder-false/renders.expected/loading.0.html
@@ -13,18 +13,4 @@
   data-from="test"
   data-slot="slot_1"
   id="GENERATED-2"
->
-  <noscript
-    id="GENERATED-3"
-  />
-</div>
-<div
-  data-from="test"
-  data-slot="slot_2"
-  id="GENERATED-4"
->
-  <noscript
-    id="GENERATED-5"
-  />
-</div>
-non-reorder data
+/>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-reorder-false/renders.expected/loading.1.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-reorder-false/renders.expected/loading.1.html
@@ -14,17 +14,7 @@
   data-slot="slot_1"
   id="GENERATED-2"
 >
-  <noscript
-    id="GENERATED-3"
-  />
+  <p>
+    test_html for slot_1
+  </p>
 </div>
-<div
-  data-from="test"
-  data-slot="slot_2"
-  id="GENERATED-4"
->
-  <noscript
-    id="GENERATED-5"
-  />
-</div>
-non-reorder data

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-reorder-false/renders.expected/loading.2.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-reorder-false/renders.expected/loading.2.html
@@ -17,26 +17,28 @@
   <p>
     test_html for slot_1
   </p>
-  <noscript
-    id="GENERATED-3"
-  />
+  next chunk for slot_1
 </div>
 <div
   data-from="test"
   data-slot="slot_2"
+  id="GENERATED-3"
+>
+  <p>
+    test_html for slot_2
+  </p>
+</div>
+non-reorder data
+<div
   id="GENERATED-4"
+  style="display:none"
 >
   <noscript
     id="GENERATED-5"
   />
 </div>
-non-reorder data
 <div
   id="GENERATED-6"
-  style="display:none"
-/>
-<div
-  id="GENERATED-7"
   style="display:none"
 />
 <script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-reorder-false/renders.expected/loading.3.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-reorder-false/renders.expected/loading.3.html
@@ -4,75 +4,35 @@
 <div
   data-src="embed"
   id="GENERATED-0"
->
-  <noscript
-    id="GENERATED-1"
-  />
-</div>
+/>
 <div
   data-from="test"
   data-slot="slot_1"
-  id="GENERATED-2"
+  id="GENERATED-1"
 >
   <p>
     test_html for slot_1
   </p>
-  <noscript
-    id="GENERATED-3"
-  />
+  next chunk for slot_1
 </div>
 <div
   data-from="test"
   data-slot="slot_2"
-  id="GENERATED-4"
+  id="GENERATED-2"
 >
   <p>
     test_html for slot_2
   </p>
-  <noscript
-    id="GENERATED-5"
-  />
 </div>
 non-reorder data
 <div
-  id="GENERATED-6"
+  id="GENERATED-3"
   style="display:none"
 />
 <div
-  id="GENERATED-7"
+  id="GENERATED-4"
   style="display:none"
 />
 <script>
   function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b&lt;f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b&lt;f;b++)c(a[b])}};$af(0);$af(1)
-</script>
-<div
-  id="GENERATED-8"
-  style="display:none"
-/>
-<script>
-  $af(2)
-</script>
-<div
-  id="GENERATED-9"
-  style="display:none"
-/>
-<div
-  id="GENERATED-10"
-  style="display:none"
->
-  next chunk for slot_1
-  <noscript
-    id="GENERATED-11"
-  />
-</div>
-<div
-  id="GENERATED-12"
-  style="display:none"
-/>
-<div
-  id="GENERATED-13"
-  style="display:none"
-/>
-<script>
-  $af(3);$af(4);$af(5);$af(6)
 </script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-reorder/renders.expected/loading.2.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-reorder/renders.expected/loading.2.html
@@ -14,9 +14,6 @@
   data-slot="slot_1"
   id="GENERATED-2"
 >
-  <p>
-    test_html for slot_1
-  </p>
   <noscript
     id="GENERATED-3"
   />
@@ -30,14 +27,26 @@
     id="GENERATED-5"
   />
 </div>
+non-reorder data
 <div
   id="GENERATED-6"
   style="display:none"
-/>
+>
+  <noscript
+    id="GENERATED-7"
+  />
+</div>
 <div
-  id="GENERATED-7"
+  id="GENERATED-8"
   style="display:none"
-/>
+>
+  <p>
+    test_html for slot_1
+  </p>
+  <noscript
+    id="GENERATED-9"
+  />
+</div>
 <script>
   function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b&lt;f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b&lt;f;b++)c(a[b])}};$af(0);$af(1)
 </script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-reorder/renders.expected/loading.4.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-reorder/renders.expected/loading.4.html
@@ -26,13 +26,11 @@
   data-slot="slot_2"
   id="GENERATED-4"
 >
-  <p>
-    test_html for slot_2
-  </p>
   <noscript
     id="GENERATED-5"
   />
 </div>
+non-reorder data
 <div
   id="GENERATED-6"
   style="display:none"
@@ -47,7 +45,14 @@
 <div
   id="GENERATED-8"
   style="display:none"
-/>
+>
+  <p>
+    test_html for slot_2
+  </p>
+  <noscript
+    id="GENERATED-9"
+  />
+</div>
 <script>
   $af(2)
 </script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-reorder/renders.expected/loading.5.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-reorder/renders.expected/loading.5.html
@@ -33,6 +33,7 @@
     id="GENERATED-5"
   />
 </div>
+non-reorder data
 <div
   id="GENERATED-6"
   style="display:none"
@@ -50,28 +51,4 @@
 />
 <script>
   $af(2)
-</script>
-<div
-  id="GENERATED-9"
-  style="display:none"
-/>
-<div
-  id="GENERATED-10"
-  style="display:none"
->
-  next chunk for slot_1
-  <noscript
-    id="GENERATED-11"
-  />
-</div>
-<div
-  id="GENERATED-12"
-  style="display:none"
-/>
-<div
-  id="GENERATED-13"
-  style="display:none"
-/>
-<script>
-  $af(3);$af(4);$af(5);$af(6)
 </script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-reorder/renders.expected/loading.7.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-client-reorder/renders.expected/loading.7.html
@@ -24,29 +24,25 @@
     test_html for slot_2
   </p>
 </div>
+non-reorder data
 <div
-  data-src="embed"
   id="GENERATED-3"
+  style="display:none"
 />
 <div
-  data-from="test2"
-  data-slot="slot_1"
   id="GENERATED-4"
->
-  <p>
-    test_2_html for slot_1
-  </p>
-  next chunk for slot_1
-</div>
+  style="display:none"
+/>
+<script>
+  function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b&lt;f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b&lt;f;b++)c(a[b])}};$af(0);$af(1)
+</script>
 <div
-  data-from="test2"
-  data-slot="slot_2"
   id="GENERATED-5"
->
-  <p>
-    test_2_html for slot_2
-  </p>
-</div>
+  style="display:none"
+/>
+<script>
+  $af(2)
+</script>
 <div
   id="GENERATED-6"
   style="display:none"
@@ -64,5 +60,5 @@
   style="display:none"
 />
 <script>
-  function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b&lt;f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b&lt;f;b++)c(a[b])}};$af(0);$af(1);$af(2);$af(3)
+  $af(3);$af(4);$af(5);$af(6)
 </script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-only/renders.expected/loading.2.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-only/renders.expected/loading.2.html
@@ -44,41 +44,4 @@
   <p>
     test_2_html for slot_1
   </p>
-  next chunk for slot_1
 </div>
-<div
-  data-from="test2"
-  data-slot="slot_2"
-  id="GENERATED-7"
->
-  <p>
-    test_2_html for slot_2
-  </p>
-</div>
-<div
-  id="GENERATED-8"
-  style="display:none"
->
-  <noscript
-    id="GENERATED-9"
-  />
-</div>
-<div
-  id="GENERATED-10"
-  style="display:none"
->
-  <noscript
-    id="GENERATED-11"
-  />
-</div>
-<div
-  id="GENERATED-12"
-  style="display:none"
-/>
-<div
-  id="GENERATED-13"
-  style="display:none"
-/>
-<script>
-  function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b&lt;f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b&lt;f;b++)c(a[b])}};$af(0);$af(1);$af(2);$af(3)
-</script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-only/renders.expected/loading.2.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-only/renders.expected/loading.2.html
@@ -44,4 +44,41 @@
   <p>
     test_2_html for slot_1
   </p>
+  next chunk for slot_1
 </div>
+<div
+  data-from="test2"
+  data-slot="slot_2"
+  id="GENERATED-7"
+>
+  <p>
+    test_2_html for slot_2
+  </p>
+</div>
+<div
+  id="GENERATED-8"
+  style="display:none"
+>
+  <noscript
+    id="GENERATED-9"
+  />
+</div>
+<div
+  id="GENERATED-10"
+  style="display:none"
+>
+  <noscript
+    id="GENERATED-11"
+  />
+</div>
+<div
+  id="GENERATED-12"
+  style="display:none"
+/>
+<div
+  id="GENERATED-13"
+  style="display:none"
+/>
+<script>
+  function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b&lt;f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b&lt;f;b++)c(a[b])}};$af(0);$af(1);$af(2);$af(3)
+</script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-only/renders.expected/loading.3.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-only/renders.expected/loading.3.html
@@ -4,15 +4,11 @@
 <div
   data-src="embed"
   id="GENERATED-0"
->
-  <noscript
-    id="GENERATED-1"
-  />
-</div>
+/>
 <div
   data-from="test"
   data-slot="slot_1"
-  id="GENERATED-2"
+  id="GENERATED-1"
 >
   <p>
     test_html for slot_1
@@ -22,7 +18,7 @@
 <div
   data-from="test"
   data-slot="slot_2"
-  id="GENERATED-3"
+  id="GENERATED-2"
 >
   <p>
     test_html for slot_2
@@ -30,16 +26,12 @@
 </div>
 <div
   data-src="embed"
-  id="GENERATED-4"
->
-  <noscript
-    id="GENERATED-5"
-  />
-</div>
+  id="GENERATED-3"
+/>
 <div
   data-from="test2"
   data-slot="slot_1"
-  id="GENERATED-6"
+  id="GENERATED-4"
 >
   <p>
     test_2_html for slot_1
@@ -49,34 +41,26 @@
 <div
   data-from="test2"
   data-slot="slot_2"
-  id="GENERATED-7"
+  id="GENERATED-5"
 >
   <p>
     test_2_html for slot_2
   </p>
 </div>
 <div
-  id="GENERATED-8"
-  style="display:none"
->
-  <noscript
-    id="GENERATED-9"
-  />
-</div>
-<div
-  id="GENERATED-10"
-  style="display:none"
->
-  <noscript
-    id="GENERATED-11"
-  />
-</div>
-<div
-  id="GENERATED-12"
+  id="GENERATED-6"
   style="display:none"
 />
 <div
-  id="GENERATED-13"
+  id="GENERATED-7"
+  style="display:none"
+/>
+<div
+  id="GENERATED-8"
+  style="display:none"
+/>
+<div
+  id="GENERATED-9"
   style="display:none"
 />
 <script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-only/renders.expected/loading.4.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-only/renders.expected/loading.4.html
@@ -4,15 +4,11 @@
 <div
   data-src="embed"
   id="GENERATED-0"
->
-  <noscript
-    id="GENERATED-1"
-  />
-</div>
+/>
 <div
   data-from="test"
   data-slot="slot_1"
-  id="GENERATED-2"
+  id="GENERATED-1"
 >
   <p>
     test_html for slot_1
@@ -22,7 +18,7 @@
 <div
   data-from="test"
   data-slot="slot_2"
-  id="GENERATED-3"
+  id="GENERATED-2"
 >
   <p>
     test_html for slot_2
@@ -30,16 +26,12 @@
 </div>
 <div
   data-src="embed"
-  id="GENERATED-4"
->
-  <noscript
-    id="GENERATED-5"
-  />
-</div>
+  id="GENERATED-3"
+/>
 <div
   data-from="test2"
   data-slot="slot_1"
-  id="GENERATED-6"
+  id="GENERATED-4"
 >
   <p>
     test_2_html for slot_1
@@ -49,34 +41,26 @@
 <div
   data-from="test2"
   data-slot="slot_2"
-  id="GENERATED-7"
+  id="GENERATED-5"
 >
   <p>
     test_2_html for slot_2
   </p>
 </div>
 <div
-  id="GENERATED-8"
-  style="display:none"
->
-  <noscript
-    id="GENERATED-9"
-  />
-</div>
-<div
-  id="GENERATED-10"
-  style="display:none"
->
-  <noscript
-    id="GENERATED-11"
-  />
-</div>
-<div
-  id="GENERATED-12"
+  id="GENERATED-6"
   style="display:none"
 />
 <div
-  id="GENERATED-13"
+  id="GENERATED-7"
+  style="display:none"
+/>
+<div
+  id="GENERATED-8"
+  style="display:none"
+/>
+<div
+  id="GENERATED-9"
   style="display:none"
 />
 <script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-timeout/renders.expected/loading.0.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-timeout/renders.expected/loading.0.html
@@ -13,18 +13,4 @@
   data-from="test"
   data-slot="slot_1"
   id="GENERATED-2"
->
-  <noscript
-    id="GENERATED-3"
-  />
-</div>
-<div
-  data-from="test"
-  data-slot="slot_2"
-  id="GENERATED-4"
->
-  <noscript
-    id="GENERATED-5"
-  />
-</div>
-non-reorder data
+/>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-timeout/renders.expected/loading.1.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-timeout/renders.expected/loading.1.html
@@ -14,17 +14,7 @@
   data-slot="slot_1"
   id="GENERATED-2"
 >
-  <noscript
-    id="GENERATED-3"
-  />
+  <p>
+    test_html for slot_1
+  </p>
 </div>
-<div
-  data-from="test"
-  data-slot="slot_2"
-  id="GENERATED-4"
->
-  <noscript
-    id="GENERATED-5"
-  />
-</div>
-non-reorder data

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-timeout/renders.expected/loading.2.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-timeout/renders.expected/loading.2.html
@@ -14,17 +14,16 @@
   data-slot="slot_1"
   id="GENERATED-2"
 >
-  <noscript
-    id="GENERATED-3"
-  />
+  <p>
+    test_html for slot_1
+  </p>
 </div>
 <div
   data-from="test"
   data-slot="slot_2"
-  id="GENERATED-4"
+  id="GENERATED-3"
 >
-  <noscript
-    id="GENERATED-5"
-  />
+  <p>
+    test_html for slot_2
+  </p>
 </div>
-non-reorder data

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-timeout/renders.expected/loading.3.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-timeout/renders.expected/loading.3.html
@@ -17,26 +17,26 @@
   <p>
     test_html for slot_1
   </p>
-  <noscript
-    id="GENERATED-3"
-  />
 </div>
 <div
   data-from="test"
   data-slot="slot_2"
+  id="GENERATED-3"
+>
+  <p>
+    test_html for slot_2
+  </p>
+</div>
+<div
   id="GENERATED-4"
+  style="display:none"
 >
   <noscript
     id="GENERATED-5"
   />
 </div>
-non-reorder data
 <div
   id="GENERATED-6"
-  style="display:none"
-/>
-<div
-  id="GENERATED-7"
   style="display:none"
 />
 <script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-timeout/renders.expected/loading.4.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-timeout/renders.expected/loading.4.html
@@ -4,75 +4,33 @@
 <div
   data-src="embed"
   id="GENERATED-0"
->
-  <noscript
-    id="GENERATED-1"
-  />
-</div>
+/>
 <div
   data-from="test"
   data-slot="slot_1"
-  id="GENERATED-2"
+  id="GENERATED-1"
 >
   <p>
     test_html for slot_1
   </p>
-  <noscript
-    id="GENERATED-3"
-  />
 </div>
 <div
   data-from="test"
   data-slot="slot_2"
-  id="GENERATED-4"
+  id="GENERATED-2"
 >
   <p>
     test_html for slot_2
   </p>
-  <noscript
-    id="GENERATED-5"
-  />
 </div>
-non-reorder data
 <div
-  id="GENERATED-6"
+  id="GENERATED-3"
   style="display:none"
 />
 <div
-  id="GENERATED-7"
+  id="GENERATED-4"
   style="display:none"
 />
 <script>
   function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b&lt;f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b&lt;f;b++)c(a[b])}};$af(0);$af(1)
-</script>
-<div
-  id="GENERATED-8"
-  style="display:none"
-/>
-<script>
-  $af(2)
-</script>
-<div
-  id="GENERATED-9"
-  style="display:none"
-/>
-<div
-  id="GENERATED-10"
-  style="display:none"
->
-  next chunk for slot_1
-  <noscript
-    id="GENERATED-11"
-  />
-</div>
-<div
-  id="GENERATED-12"
-  style="display:none"
-/>
-<div
-  id="GENERATED-13"
-  style="display:none"
-/>
-<script>
-  $af(3);$af(4);$af(5);$af(6)
 </script>

--- a/src/components/micro-frame-sse/__tests__/fixtures/ssr-client-reorder-false/embed.marko
+++ b/src/components/micro-frame-sse/__tests__/fixtures/ssr-client-reorder-false/embed.marko
@@ -1,0 +1,25 @@
+import { wait } from "../../../../../__tests__/queue";
+import fs from "fs";
+import path from "path";
+
+$ const slot_1_html = fs.readFileSync(path.resolve(__dirname ,'slot_1.html'), 'utf8');
+$ const slot_2_html = fs.readFileSync(path.resolve(__dirname ,'slot_2.html'), 'utf8');
+$ const first = `id: slot_1\ndata: ${slot_1_html.replace(/\r?\n/g, '')}\n\n`;
+$ const second = `id: slot_2\ndata: ${slot_2_html.replace(/\r?\n/g, '')}\n\n`;
+$ const third = `id: slot_1\ntype: update\ndata: next chunk for slot_1`;
+
+<await(wait())>
+  <@then>
+    $!{first}
+    <await(wait())>
+      <@then>
+        $!{second}
+        <await(wait())>
+          <@then>
+            $!{third}
+          </@then>
+        </await>
+      </@then>
+    </await>
+  </@then>
+</await>

--- a/src/components/micro-frame-sse/__tests__/fixtures/ssr-client-reorder-false/index.marko
+++ b/src/components/micro-frame-sse/__tests__/fixtures/ssr-client-reorder-false/index.marko
@@ -9,8 +9,8 @@
 <body>
   <div>Host app</div>
 <micro-frame-sse src="embed" name="test" read=(e => [e.lastEventId, e.data]) />
-<micro-frame-slot from="test" slot="slot_1" client-reorder />
-<micro-frame-slot from="test" slot="slot_2" client-reorder />
+<micro-frame-slot from="test" slot="slot_1" />
+<micro-frame-slot from="test" slot="slot_2" />
 <await(new Promise(res => setTimeout(() => res('non-reorder data'))))>
   <@then|result|>
     ${result}

--- a/src/components/micro-frame-sse/__tests__/fixtures/ssr-client-reorder-false/slot_1.html
+++ b/src/components/micro-frame-sse/__tests__/fixtures/ssr-client-reorder-false/slot_1.html
@@ -1,0 +1,1 @@
+<p>test_html for slot_1</p>

--- a/src/components/micro-frame-sse/__tests__/fixtures/ssr-client-reorder-false/slot_2.html
+++ b/src/components/micro-frame-sse/__tests__/fixtures/ssr-client-reorder-false/slot_2.html
@@ -1,0 +1,1 @@
+<p>test_html for slot_2</p>

--- a/src/components/micro-frame-sse/__tests__/fixtures/ssr-timeout/embed.marko
+++ b/src/components/micro-frame-sse/__tests__/fixtures/ssr-timeout/embed.marko
@@ -1,0 +1,25 @@
+import { wait } from "../../../../../__tests__/queue";
+import fs from "fs";
+import path from "path";
+
+$ const slot_1_html = fs.readFileSync(path.resolve(__dirname ,'slot_1.html'), 'utf8');
+$ const slot_2_html = fs.readFileSync(path.resolve(__dirname ,'slot_2.html'), 'utf8');
+$ const first = `id: slot_1\ndata: ${slot_1_html.replace(/\r?\n/g, '')}\n\n`;
+$ const second = `id: slot_2\ndata: ${slot_2_html.replace(/\r?\n/g, '')}\n\n`;
+$ const third = `id: slot_1\ntype: update\ndata: next chunk for slot_1`;
+
+<await(wait())>
+  <@then>
+    $!{first}
+    <await(wait())>
+      <@then>
+        $!{second}
+        <await(new Promise(res => setTimeout(res, 2000)))>
+          <@then>
+            $!{third}
+          </@then>
+        </await>
+      </@then>
+    </await>
+  </@then>
+</await>

--- a/src/components/micro-frame-sse/__tests__/fixtures/ssr-timeout/index.marko
+++ b/src/components/micro-frame-sse/__tests__/fixtures/ssr-timeout/index.marko
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Simple Example</title>
+  <esbuild-assets/>
+</head>
+<body>
+  <div>Host app</div>
+  <micro-frame-sse src="embed" name="test" read=(e => [e.lastEventId, e.data]) />
+  <micro-frame-slot from="test" slot="slot_1" timeout=1000 />
+  <micro-frame-slot from="test" slot="slot_2" />
+</body>
+</html>

--- a/src/components/micro-frame-sse/__tests__/fixtures/ssr-timeout/slot_1.html
+++ b/src/components/micro-frame-sse/__tests__/fixtures/ssr-timeout/slot_1.html
@@ -1,0 +1,1 @@
+<p>test_html for slot_1</p>

--- a/src/components/micro-frame-sse/__tests__/fixtures/ssr-timeout/slot_2.html
+++ b/src/components/micro-frame-sse/__tests__/fixtures/ssr-timeout/slot_2.html
@@ -1,0 +1,1 @@
+<p>test_html for slot_2</p>

--- a/src/components/micro-frame-sse/__tests__/server.test.ts
+++ b/src/components/micro-frame-sse/__tests__/server.test.ts
@@ -186,4 +186,14 @@ describe("micro-frame-sse", () => {
     "ssr client-reorder",
     fixture(path.join(__dirname, "fixtures/ssr-client-reorder"))
   );
+
+  describe(
+    "ssr client-reorder false",
+    fixture(path.join(__dirname, "fixtures/ssr-client-reorder-false"))
+  );
+
+  describe(
+    "ssr timeout",
+    fixture(path.join(__dirname, "fixtures/ssr-timeout"))
+  );
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add back missing `timeout` attribute for `micro-frame-slot` tag.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
