### PR TITLE
fix: fix a bug that a delayed micro-frame-slot renders with a non-existing ID

### DIFF
--- a/src/components/micro-frame-slot/component/node.marko
+++ b/src/components/micro-frame-slot/component/node.marko
@@ -40,10 +40,12 @@ $ {
       </await>
     </macro>
     $ out.bf("@_", component, true);
-    <if(input.loading)>
-      <await(loadingPromise) placeholder=input.loading client-reorder/>
+    <if(stream)>
+      <if(input.loading)>
+        <await(loadingPromise) placeholder=input.loading client-reorder/>
+      </if>
+      <wait/>
     </if>
-    <wait/>
     $ out.ef();
   </div>
 </else>

--- a/src/components/micro-frame-slot/component/web.component.ts
+++ b/src/components/micro-frame-slot/component/web.component.ts
@@ -65,6 +65,10 @@ export = {
 
       this.slot = streamSource.slot(this.slotId);
 
+      if (!this.slot) {
+        return;
+      }
+
       writable = getWritableDOM(
         this.el,
         // references the start of the preserved Marko fragment.

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-delayed-slot/renders.expected/loading.1.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-delayed-slot/renders.expected/loading.1.html
@@ -29,15 +29,20 @@
   </p>
 </div>
 <div
+  data-from="test"
+  data-slot="non_exist"
   id="GENERATED-4"
+/>
+<div
+  id="GENERATED-5"
   style="display:none"
 >
   <noscript
-    id="GENERATED-5"
+    id="GENERATED-6"
   />
 </div>
 <div
-  id="GENERATED-6"
+  id="GENERATED-7"
   style="display:none"
 />
 <script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-delayed-slot/renders.expected/loading.2.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-delayed-slot/renders.expected/loading.2.html
@@ -25,11 +25,16 @@
   </p>
 </div>
 <div
+  data-from="test"
+  data-slot="non_exist"
   id="GENERATED-3"
-  style="display:none"
 />
 <div
   id="GENERATED-4"
+  style="display:none"
+/>
+<div
+  id="GENERATED-5"
   style="display:none"
 />
 <script>

--- a/src/components/micro-frame-sse/__tests__/fixtures/ssr-delayed-slot/index.marko
+++ b/src/components/micro-frame-sse/__tests__/fixtures/ssr-delayed-slot/index.marko
@@ -11,8 +11,21 @@
   <micro-frame-sse src="embed" name="test" read=(e => [e.lastEventId, e.data]) />
   <await(new Promise(res => setTimeout(res, 1000)))>
     <@then>
-      <micro-frame-slot from="test" slot="slot_1" />
-      <micro-frame-slot from="test" slot="slot_2" />
+      <micro-frame-slot from="test" slot="slot_1">
+        <@catch|err|>
+          Slot_1 Error: ${err.message}
+        </@catch>
+      </micro-frame-slot>
+      <micro-frame-slot from="test" slot="slot_2">
+        <@catch|err|>
+          Slot_2 Error: ${err.message}
+        </@catch>
+      </micro-frame-slot>
+      <micro-frame-slot from="test" slot="non_exist" timeout=200>
+        <@catch|err|>
+          non_exist Error: ${err.message}
+        </@catch>
+      </micro-frame-slot>
     </@then>
   </await>
 </body>

--- a/src/components/stream-source/component/StreamSource.ts
+++ b/src/components/stream-source/component/StreamSource.ts
@@ -3,6 +3,7 @@ import createWritable, { StreamWritable } from "./StreamWritable";
 export const STREAM_SOURCE_MAP: Map<string, StreamSource> = new Map();
 class StreamSource {
   private readonly _slots: Map<string, StreamWritable>;
+  private _closed: boolean;
 
   private getOrCreateSlot(id: string): StreamWritable {
     if (this._slots.has(id)) {
@@ -16,6 +17,7 @@ class StreamSource {
 
   constructor() {
     this._slots = new Map();
+    this._closed = false;
   }
 
   async run(parserIterator: AsyncIterator<string[]>) {
@@ -35,10 +37,11 @@ class StreamSource {
   }
 
   slot(id: string) {
-    return this.getOrCreateSlot(id);
+    return this._closed ? this._slots.get(id) : this.getOrCreateSlot(id);
   }
 
   close(err?: Error) {
+    this._closed = true;
     this._slots.forEach((slot: StreamWritable) =>
       err ? slot.error(err) : slot.end()
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When a `<micro-frame-slot />` renders after `<micro-frame-sse />` is already closed and the slotId does not exist in StreamSource, the slot will keep loading until it timeout.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
