### PR TITLE
fix: moving STREAM_SOURCE_MAP to out.global in server side

### DIFF
--- a/src/components/micro-frame-slot/component/node.marko
+++ b/src/components/micro-frame-slot/component/node.marko
@@ -1,8 +1,8 @@
-import StreamSource, { STREAM_SOURCE_MAP } from "../../stream-source/component/StreamSource";
+import StreamSource from "../../stream-source/component/StreamSource";
 $ const sourceName = input.from;
 $ let err;
 $ {
-  if (!STREAM_SOURCE_MAP.has(sourceName))
+  if (!out.global.STREAM_SOURCE_MAP_SERVER || !out.global.STREAM_SOURCE_MAP_SERVER.has(sourceName))
     err = new Error(`micro-frame-sse ${sourceName} is not defined.`);
 }
 
@@ -11,7 +11,7 @@ $ {
   <${input.catch}(err)/>
 </if>
 <else>
-  $ const streamSource = STREAM_SOURCE_MAP.get(sourceName);
+  $ const streamSource = out.global.STREAM_SOURCE_MAP_SERVER.get(sourceName);
   $ const stream = streamSource.slot(input.slot);
   $ let finishLoading;
   $ {

--- a/src/components/micro-frame-slot/component/web.component.ts
+++ b/src/components/micro-frame-slot/component/web.component.ts
@@ -1,5 +1,5 @@
 import { StreamWritable } from "../../stream-source/component/StreamWritable";
-import { STREAM_SOURCE_MAP } from "../../stream-source/component/StreamSource";
+import { STREAM_SOURCE_MAP_CLIENT } from "../../stream-source/component/StreamSource";
 import getWritableDOM from "writable-dom";
 
 interface Input {
@@ -55,7 +55,7 @@ export = {
     let err: Error | undefined;
 
     try {
-      const streamSource = STREAM_SOURCE_MAP.get(this.from);
+      const streamSource = STREAM_SOURCE_MAP_CLIENT.get(this.from);
       // In case of micro-frame-sse pure server-side rendered,
       // throw error when the slot trying to connect to the stream
       if (!streamSource)

--- a/src/components/stream-source/component/StreamSource.ts
+++ b/src/components/stream-source/component/StreamSource.ts
@@ -1,6 +1,6 @@
 import createWritable, { StreamWritable } from "./StreamWritable";
 
-export const STREAM_SOURCE_MAP: Map<string, StreamSource> = new Map();
+export const STREAM_SOURCE_MAP_CLIENT: Map<string, StreamSource> = new Map();
 class StreamSource {
   private readonly _slots: Map<string, StreamWritable>;
   private _closed: boolean;

--- a/src/components/stream-source/component/node.marko
+++ b/src/components/stream-source/component/node.marko
@@ -1,6 +1,6 @@
 import fetch from "make-fetch-happen";
 import path from "path";
-import StreamSource, { STREAM_SOURCE_MAP } from "./StreamSource";
+import StreamSource from "./StreamSource";
 
 static const cachePath = path.resolve("node_modules/.cache/fetch");
 
@@ -27,8 +27,13 @@ $ const request = async () => {
   return res;
 }
 
-$ const streamSource = new StreamSource();
-$ STREAM_SOURCE_MAP.set(input.name, streamSource);
+$ {
+  const streamSource = new StreamSource();
+  if (out.global.STREAM_SOURCE_MAP_SERVER === undefined) {
+    out.global.STREAM_SOURCE_MAP_SERVER = new Map();
+  }
+  out.global.STREAM_SOURCE_MAP_SERVER.set(input.name, streamSource);
+}
 
 <div id=component.id data-src=input.src>
   $ out.bf("@_", component, true);

--- a/src/components/stream-source/component/web.component.ts
+++ b/src/components/stream-source/component/web.component.ts
@@ -1,4 +1,4 @@
-import StreamSource, { STREAM_SOURCE_MAP } from "./StreamSource";
+import StreamSource, { STREAM_SOURCE_MAP_CLIENT } from "./StreamSource";
 
 interface Input {
   src: string;
@@ -43,7 +43,7 @@ export = {
       ssrEl.removeAttribute("id");
     } else {
       const streamSource = new StreamSource();
-      STREAM_SOURCE_MAP.set(input.name, streamSource);
+      STREAM_SOURCE_MAP_CLIENT.set(input.name, streamSource);
       this.streamSource = streamSource;
     }
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Having STREAM_SOURCE_MAP in module will cause issue when there is concurrency where the second request coming before the `micro-frame-slot` is reading STREAM_SOURCE_MAP. Also storing STREAM_SOURCE_MAP in module will make it persist in server and can cause memory issue.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
