### PR TITLE
Fix stream source for marko 4

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+package-lock.json -diff
+src/node_modules/** linguist-generated=false

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,4 +1,4 @@
 {
-  "*.ts": ["eslint --fix", "prettier --write -u"],
-  "*{.js,.json,.md,.yml,rc}": ["prettier --write -u"]
+  "*.ts": ["eslint --fix", "prettier --write -u --with-node-modules"],
+  "*{.js,.json,.md,.yml,rc}": ["prettier --write -u --with-node-modules"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "mocha-snap": "^4.0.2",
         "nyc": "^15.1.0",
         "playwright": "^1.16.1",
-        "prettier": "^2.4.1",
+        "prettier": "^2.8.8",
         "replace": "^1.2.1",
         "semantic-release": "^18.0.0",
         "typescript": "^4.4.4"
@@ -10821,15 +10821,18 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
-      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
       "engines": {
         "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {
@@ -21493,9 +21496,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
-      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true
     },
     "pretty-format": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "mocha-snap": "^4.0.2",
     "nyc": "^15.1.0",
     "playwright": "^1.16.1",
-    "prettier": "^2.4.1",
+    "prettier": "^2.8.8",
     "replace": "^1.2.1",
     "semantic-release": "^18.0.0",
     "typescript": "^4.4.4"
@@ -72,7 +72,7 @@
     "format": "npm run lint:eslint -- --fix && npm run lint:prettier -- --write && (fixpack || true)",
     "lint": "tsc -b && npm run lint:eslint && npm run lint:prettier -- -l && fixpack",
     "lint:eslint": "eslint -f visualstudio .",
-    "lint:prettier": "prettier '**/*{.ts,.js,.json,.md,.yml,rc}'",
+    "lint:prettier": "prettier 'src/**/*{.ts,.js,.json,.md,.yml,rc}' --with-node-modules",
     "mocha": "NODE_ENV=test mocha 'src/**/__tests__/*.test.ts'",
     "postpublish": "replace --silent 'dist' 'src' marko.json",
     "prepare": "husky install",

--- a/src/node_modules/@internal/micro-frame-slot-component/web.component.ts
+++ b/src/node_modules/@internal/micro-frame-slot-component/web.component.ts
@@ -1,5 +1,9 @@
 import getWritableDOM from "writable-dom";
-import { getSource, type StreamSource, type StreamWritable } from "../../../util/stream";
+import {
+  getSource,
+  type StreamSource,
+  type StreamWritable,
+} from "../../../util/stream";
 
 interface Input {
   slot: string;

--- a/src/node_modules/@internal/stream-source-component/package.json
+++ b/src/node_modules/@internal/stream-source-component/package.json
@@ -1,5 +1,11 @@
 {
   "name": "@internal/stream-source-component",
   "main": "./node.marko",
-  "browser": "./web.marko"
+  "browser": "./web.marko",
+  "exports": {
+    ".": {
+      "browser": "./web.marko",
+      "default": "./node.marko"
+    }
+  }
 }

--- a/src/node_modules/@internal/stream-source-component/web.component.ts
+++ b/src/node_modules/@internal/stream-source-component/web.component.ts
@@ -34,7 +34,7 @@ function readableToAsyncIterator(
   };
 }
 
-export default {
+export = {
   onCreate() {
     const ssrEl = document.getElementById(this.id);
     if (ssrEl) {
@@ -70,7 +70,9 @@ export default {
         signal: controller.signal,
       });
       if (!res.ok) throw new Error(res.statusText);
-      await this.streamSource.run(this.input.parser(readableToAsyncIterator(res.body!)));
+      await this.streamSource.run(
+        this.input.parser(readableToAsyncIterator(res.body!))
+      );
     } catch (_err) {
       err = _err as Error;
       this.streamSource.close(err);


### PR DESCRIPTION
## Description

The previous patch in #20 causes a regression in Marko 4 since it switched the `component.ts` to use `export default` instead of `export =`. This PR reverts that change.

This PR also ensures that prettier properly runs against files in the `@internal` node_modules.
