### PR TITLE
feat: only show loading indicator before first chunk and allow new client-reorder parameter ("after-first-chunk")

### DIFF
--- a/src/components/micro-frame-slot/marko-tag.json
+++ b/src/components/micro-frame-slot/marko-tag.json
@@ -17,10 +17,9 @@
     ]
   },
   "@client-reorder": {
-    "type": "boolean",
     "autocomplete": [
       {
-        "description": "See client-reorder in <await>",
+        "description": "See client-reorder in <await>. Also support additional 'after-first-chunk' value.",
         "descriptionMoreURL": "https://markojs.com/docs/core-tags/#await"
       }
     ]

--- a/src/components/micro-frame-sse/README.md
+++ b/src/components/micro-frame-sse/README.md
@@ -189,6 +189,14 @@ Flag indicate if the slot need to be streamed out-of-order. Please refer to [cli
 <micro-frame-slot from="..." slot="..." client-reorder />
 ```
 
+### `client-reorder="after-first-chunk"`
+
+There is an additional value supported here which is `after-first-chunk`. When set, the slot will be rendered in-order before first chunk and will convert to out-of-order while streaming. This is useful when loading indicator is controlled inside stream.
+
+```marko
+<micro-frame-slot from="..." slot="..." client-reorder="after-first-chunk" />
+```
+
 ## `timeout` in slot
 
 A timeout in `ms` (defaults to 30s) that will prematurely abort the slot. This will trigger the `<@catch>` if provided.

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/csr-stream-loading/renders.expected/loading.3.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/csr-stream-loading/renders.expected/loading.3.html
@@ -3,16 +3,12 @@
 </div>
 <div />
 <div>
-  Loading...
   <p>
     test_html for slot_1
   </p>
 </div>
 <div>
   Loading...
-  <p>
-    test_html for slot_2
-  </p>
 </div>
 <script>
   $csr_stream_loading_index_C=(window.$csr_stream_loading_index_C||[]).concat({"l":1,"w":[["s0-8",0,{},{"f":1}]],"t":["7xb9FY2M"]})

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/csr-stream-loading/renders.expected/loading.4.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/csr-stream-loading/renders.expected/loading.4.html
@@ -3,11 +3,9 @@
 </div>
 <div />
 <div>
-  Loading...
   <p>
     test_html for slot_1
   </p>
-  next chunk for slot_1
 </div>
 <div>
   Loading...

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/csr-stream-loading/renders.expected/loading.6.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/csr-stream-loading/renders.expected/loading.6.html
@@ -6,6 +6,7 @@
   <p>
     test_html for slot_1
   </p>
+  next chunk for slot_1
 </div>
 <div>
   <p>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-reorder-after-first-chunk/renders.expected/loading.0.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-reorder-after-first-chunk/renders.expected/loading.0.html
@@ -1,0 +1,16 @@
+<div>
+  Host app
+</div>
+<div
+  data-src="embed"
+  id="GENERATED-0"
+>
+  <noscript
+    id="GENERATED-1"
+  />
+</div>
+<div
+  data-from="test"
+  data-slot="slot_1"
+  id="GENERATED-2"
+/>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-reorder-after-first-chunk/renders.expected/loading.1.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-reorder-after-first-chunk/renders.expected/loading.1.html
@@ -1,0 +1,44 @@
+<div>
+  Host app
+</div>
+<div
+  data-src="embed"
+  id="GENERATED-0"
+>
+  <noscript
+    id="GENERATED-1"
+  />
+</div>
+<div
+  data-from="test"
+  data-slot="slot_1"
+  id="GENERATED-2"
+>
+  <p>
+    test_html for slot_1
+  </p>
+  <noscript
+    id="GENERATED-3"
+  />
+</div>
+<div
+  data-from="test"
+  data-slot="slot_2"
+  id="GENERATED-4"
+>
+  <noscript
+    id="GENERATED-5"
+  />
+</div>
+non-reorder data
+<div
+  id="GENERATED-6"
+  style="display:none"
+>
+  <noscript
+    id="GENERATED-7"
+  />
+</div>
+<script>
+  function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b&lt;f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b&lt;f;b++)c(a[b])}};$af(0)
+</script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-reorder-after-first-chunk/renders.expected/loading.2.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-reorder-after-first-chunk/renders.expected/loading.2.html
@@ -1,0 +1,40 @@
+<div>
+  Host app
+</div>
+<div
+  data-src="embed"
+  id="GENERATED-0"
+>
+  <noscript
+    id="GENERATED-1"
+  />
+</div>
+<div
+  data-from="test"
+  data-slot="slot_1"
+  id="GENERATED-2"
+>
+  <p>
+    test_html for slot_1
+  </p>
+  <noscript
+    id="GENERATED-3"
+  />
+</div>
+<div
+  data-from="test"
+  data-slot="slot_2"
+  id="GENERATED-4"
+>
+  <noscript
+    id="GENERATED-5"
+  />
+</div>
+non-reorder data
+<div
+  id="GENERATED-6"
+  style="display:none"
+/>
+<script>
+  function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b&lt;f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b&lt;f;b++)c(a[b])}};$af(0)
+</script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-reorder-after-first-chunk/renders.expected/loading.3.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-reorder-after-first-chunk/renders.expected/loading.3.html
@@ -1,0 +1,54 @@
+<div>
+  Host app
+</div>
+<div
+  data-src="embed"
+  id="GENERATED-0"
+>
+  <noscript
+    id="GENERATED-1"
+  />
+</div>
+<div
+  data-from="test"
+  data-slot="slot_1"
+  id="GENERATED-2"
+>
+  <p>
+    test_html for slot_1
+  </p>
+  <noscript
+    id="GENERATED-3"
+  />
+</div>
+<div
+  data-from="test"
+  data-slot="slot_2"
+  id="GENERATED-4"
+>
+  <noscript
+    id="GENERATED-5"
+  />
+</div>
+non-reorder data
+<div
+  id="GENERATED-6"
+  style="display:none"
+/>
+<script>
+  function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b&lt;f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b&lt;f;b++)c(a[b])}};$af(0)
+</script>
+<div
+  id="GENERATED-7"
+  style="display:none"
+>
+  <p>
+    test_html for slot_2
+  </p>
+  <noscript
+    id="GENERATED-8"
+  />
+</div>
+<script>
+  $af(1)
+</script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-reorder-after-first-chunk/renders.expected/loading.4.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-reorder-after-first-chunk/renders.expected/loading.4.html
@@ -1,0 +1,50 @@
+<div>
+  Host app
+</div>
+<div
+  data-src="embed"
+  id="GENERATED-0"
+>
+  <noscript
+    id="GENERATED-1"
+  />
+</div>
+<div
+  data-from="test"
+  data-slot="slot_1"
+  id="GENERATED-2"
+>
+  <p>
+    test_html for slot_1
+  </p>
+  <noscript
+    id="GENERATED-3"
+  />
+</div>
+<div
+  data-from="test"
+  data-slot="slot_2"
+  id="GENERATED-4"
+>
+  <p>
+    test_html for slot_2
+  </p>
+  <noscript
+    id="GENERATED-5"
+  />
+</div>
+non-reorder data
+<div
+  id="GENERATED-6"
+  style="display:none"
+/>
+<script>
+  function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b&lt;f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b&lt;f;b++)c(a[b])}};$af(0)
+</script>
+<div
+  id="GENERATED-7"
+  style="display:none"
+/>
+<script>
+  $af(1)
+</script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-reorder-after-first-chunk/renders.expected/loading.5.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-reorder-after-first-chunk/renders.expected/loading.5.html
@@ -1,0 +1,74 @@
+<div>
+  Host app
+</div>
+<div
+  data-src="embed"
+  id="GENERATED-0"
+>
+  <noscript
+    id="GENERATED-1"
+  />
+</div>
+<div
+  data-from="test"
+  data-slot="slot_1"
+  id="GENERATED-2"
+>
+  <p>
+    test_html for slot_1
+  </p>
+  <noscript
+    id="GENERATED-3"
+  />
+</div>
+<div
+  data-from="test"
+  data-slot="slot_2"
+  id="GENERATED-4"
+>
+  <p>
+    test_html for slot_2
+  </p>
+  <noscript
+    id="GENERATED-5"
+  />
+</div>
+non-reorder data
+<div
+  id="GENERATED-6"
+  style="display:none"
+/>
+<script>
+  function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b&lt;f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b&lt;f;b++)c(a[b])}};$af(0)
+</script>
+<div
+  id="GENERATED-7"
+  style="display:none"
+/>
+<script>
+  $af(1)
+</script>
+<div
+  id="GENERATED-8"
+  style="display:none"
+/>
+<div
+  id="GENERATED-9"
+  style="display:none"
+>
+  next chunk for slot_1
+  <noscript
+    id="GENERATED-10"
+  />
+</div>
+<div
+  id="GENERATED-11"
+  style="display:none"
+/>
+<div
+  id="GENERATED-12"
+  style="display:none"
+/>
+<script>
+  $af(2);$af(3);$af(4);$af(5)
+</script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-reorder-after-first-chunk/renders.expected/loading.6.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-reorder-after-first-chunk/renders.expected/loading.6.html
@@ -1,0 +1,60 @@
+<div>
+  Host app
+</div>
+<div
+  data-src="embed"
+  id="GENERATED-0"
+/>
+<div
+  data-from="test"
+  data-slot="slot_1"
+  id="GENERATED-1"
+>
+  <p>
+    test_html for slot_1
+  </p>
+  next chunk for slot_1
+</div>
+<div
+  data-from="test"
+  data-slot="slot_2"
+  id="GENERATED-2"
+>
+  <p>
+    test_html for slot_2
+  </p>
+</div>
+non-reorder data
+<div
+  id="GENERATED-3"
+  style="display:none"
+/>
+<script>
+  function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b&lt;f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b&lt;f;b++)c(a[b])}};$af(0)
+</script>
+<div
+  id="GENERATED-4"
+  style="display:none"
+/>
+<script>
+  $af(1)
+</script>
+<div
+  id="GENERATED-5"
+  style="display:none"
+/>
+<div
+  id="GENERATED-6"
+  style="display:none"
+/>
+<div
+  id="GENERATED-7"
+  style="display:none"
+/>
+<div
+  id="GENERATED-8"
+  style="display:none"
+/>
+<script>
+  $af(2);$af(3);$af(4);$af(5)
+</script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-slot-done-signal/renders.expected/loading.0.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-slot-done-signal/renders.expected/loading.0.html
@@ -13,10 +13,4 @@
   data-from="test"
   data-slot="slot_1"
   id="GENERATED-2"
->
-  <span
-    id="GENERATED-3"
-  >
-    Loading...
-  </span>
-</div>
+/>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-slot-done-signal/renders.expected/loading.1.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-slot-done-signal/renders.expected/loading.1.html
@@ -14,11 +14,6 @@
   data-slot="slot_1"
   id="GENERATED-2"
 >
-  <span
-    id="GENERATED-3"
-  >
-    Loading...
-  </span>
   <p>
     test_html for slot_1
   </p>
@@ -26,11 +21,5 @@
 <div
   data-from="test"
   data-slot="slot_2"
-  id="GENERATED-4"
->
-  <span
-    id="GENERATED-5"
-  >
-    Loading...
-  </span>
-</div>
+  id="GENERATED-3"
+/>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-slot-done-signal/renders.expected/loading.2.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-slot-done-signal/renders.expected/loading.2.html
@@ -14,11 +14,6 @@
   data-slot="slot_1"
   id="GENERATED-2"
 >
-  <span
-    id="GENERATED-3"
-  >
-    Loading...
-  </span>
   <p>
     test_html for slot_1
   </p>
@@ -26,33 +21,20 @@
 <div
   data-from="test"
   data-slot="slot_2"
-  id="GENERATED-4"
+  id="GENERATED-3"
 >
-  <span
-    id="GENERATED-5"
-  >
-    Loading...
-  </span>
   <p>
     test_html for slot_2
   </p>
 </div>
 <div
-  id="GENERATED-6"
+  id="GENERATED-4"
   style="display:none"
 >
   <noscript
-    id="GENERATED-7"
+    id="GENERATED-5"
   />
 </div>
-<div
-  id="GENERATED-8"
-  style="display:none"
-/>
-<div
-  id="GENERATED-9"
-  style="display:none"
-/>
 <script>
-  function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b&lt;f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b&lt;f;b++)c(a[b])}};$af(0);$af(1);$af(2)
+  function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b&lt;f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b&lt;f;b++)c(a[b])}};$af(0)
 </script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-slot-done-signal/renders.expected/loading.3.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-slot-done-signal/renders.expected/loading.3.html
@@ -31,14 +31,6 @@
   id="GENERATED-4"
   style="display:none"
 />
-<div
-  id="GENERATED-5"
-  style="display:none"
-/>
-<div
-  id="GENERATED-6"
-  style="display:none"
-/>
 <script>
-  function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b&lt;f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b&lt;f;b++)c(a[b])}};$af(0);$af(1);$af(2)
+  function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b&lt;f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b&lt;f;b++)c(a[b])}};$af(0)
 </script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-slot-done-signal/renders.expected/loading.4.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-slot-done-signal/renders.expected/loading.4.html
@@ -31,21 +31,13 @@
   id="GENERATED-4"
   style="display:none"
 />
+<script>
+  function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b&lt;f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b&lt;f;b++)c(a[b])}};$af(0)
+</script>
 <div
   id="GENERATED-5"
   style="display:none"
 />
-<div
-  id="GENERATED-6"
-  style="display:none"
-/>
 <script>
-  function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b&lt;f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b&lt;f;b++)c(a[b])}};$af(0);$af(1);$af(2)
-</script>
-<div
-  id="GENERATED-7"
-  style="display:none"
-/>
-<script>
-  $af(3)
+  $af(1)
 </script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-slot-done-signal/renders.expected/loading.5.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-slot-done-signal/renders.expected/loading.5.html
@@ -27,21 +27,13 @@
   id="GENERATED-3"
   style="display:none"
 />
+<script>
+  function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b&lt;f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b&lt;f;b++)c(a[b])}};$af(0)
+</script>
 <div
   id="GENERATED-4"
   style="display:none"
 />
-<div
-  id="GENERATED-5"
-  style="display:none"
-/>
 <script>
-  function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b&lt;f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b&lt;f;b++)c(a[b])}};$af(0);$af(1);$af(2)
-</script>
-<div
-  id="GENERATED-6"
-  style="display:none"
-/>
-<script>
-  $af(3)
+  $af(1)
 </script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-stream-loading/renders.expected/loading.0.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-stream-loading/renders.expected/loading.0.html
@@ -20,3 +20,14 @@
     Loading...
   </span>
 </div>
+<div
+  data-from="test"
+  data-slot="slot_2"
+  id="GENERATED-4"
+>
+  <span
+    id="GENERATED-5"
+  >
+    Loading...
+  </span>
+</div>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-stream-loading/renders.expected/loading.1.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-stream-loading/renders.expected/loading.1.html
@@ -19,7 +19,37 @@
   >
     Loading...
   </span>
+</div>
+<div
+  data-from="test"
+  data-slot="slot_2"
+  id="GENERATED-4"
+>
+  <span
+    id="GENERATED-5"
+  >
+    Loading...
+  </span>
+</div>
+<div
+  id="GENERATED-6"
+  style="display:none"
+>
+  <noscript
+    id="GENERATED-7"
+  />
+</div>
+<div
+  id="GENERATED-8"
+  style="display:none"
+>
   <p>
     test_html for slot_1
   </p>
+  <noscript
+    id="GENERATED-9"
+  />
 </div>
+<script>
+  function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b&lt;f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b&lt;f;b++)c(a[b])}};$af(0);$af(1)
+</script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-stream-loading/renders.expected/loading.3.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-stream-loading/renders.expected/loading.3.html
@@ -14,15 +14,12 @@
   data-slot="slot_1"
   id="GENERATED-2"
 >
-  <span
-    id="GENERATED-3"
-  >
-    Loading...
-  </span>
   <p>
     test_html for slot_1
   </p>
-  next chunk for slot_1
+  <noscript
+    id="GENERATED-3"
+  />
 </div>
 <div
   data-from="test"
@@ -34,30 +31,29 @@
   >
     Loading...
   </span>
-  <p>
-    test_html for slot_2
-  </p>
 </div>
 <div
   id="GENERATED-6"
   style="display:none"
->
-  <noscript
-    id="GENERATED-7"
-  />
-</div>
-<div
-  id="GENERATED-8"
-  style="display:none"
 />
 <div
-  id="GENERATED-9"
-  style="display:none"
-/>
-<div
-  id="GENERATED-10"
+  id="GENERATED-7"
   style="display:none"
 />
 <script>
-  function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b&lt;f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b&lt;f;b++)c(a[b])}};$af(0);$af(3);$af(1);$af(2)
+  function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b&lt;f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b&lt;f;b++)c(a[b])}};$af(0);$af(1)
+</script>
+<div
+  id="GENERATED-8"
+  style="display:none"
+>
+  <p>
+    test_html for slot_2
+  </p>
+  <noscript
+    id="GENERATED-9"
+  />
+</div>
+<script>
+  $af(2)
 </script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-stream-loading/renders.expected/loading.4.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-stream-loading/renders.expected/loading.4.html
@@ -4,42 +4,50 @@
 <div
   data-src="embed"
   id="GENERATED-0"
-/>
+>
+  <noscript
+    id="GENERATED-1"
+  />
+</div>
 <div
   data-from="test"
   data-slot="slot_1"
-  id="GENERATED-1"
+  id="GENERATED-2"
 >
   <p>
     test_html for slot_1
   </p>
-  next chunk for slot_1
+  <noscript
+    id="GENERATED-3"
+  />
 </div>
 <div
   data-from="test"
   data-slot="slot_2"
-  id="GENERATED-2"
+  id="GENERATED-4"
 >
   <p>
     test_html for slot_2
   </p>
+  <noscript
+    id="GENERATED-5"
+  />
 </div>
-<div
-  id="GENERATED-3"
-  style="display:none"
-/>
-<div
-  id="GENERATED-4"
-  style="display:none"
-/>
-<div
-  id="GENERATED-5"
-  style="display:none"
-/>
 <div
   id="GENERATED-6"
   style="display:none"
 />
+<div
+  id="GENERATED-7"
+  style="display:none"
+/>
 <script>
-  function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b&lt;f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b&lt;f;b++)c(a[b])}};$af(0);$af(3);$af(1);$af(2)
+  function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b&lt;f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b&lt;f;b++)c(a[b])}};$af(0);$af(1)
+</script>
+<div
+  id="GENERATED-8"
+  style="display:none"
+/>
+<script>
+  $af(2)
 </script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-stream-loading/renders.expected/loading.5.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-stream-loading/renders.expected/loading.5.html
@@ -26,11 +26,12 @@
   data-slot="slot_2"
   id="GENERATED-4"
 >
-  <span
+  <p>
+    test_html for slot_2
+  </p>
+  <noscript
     id="GENERATED-5"
-  >
-    Loading...
-  </span>
+  />
 </div>
 <div
   id="GENERATED-6"
@@ -42,4 +43,32 @@
 />
 <script>
   function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b&lt;f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b&lt;f;b++)c(a[b])}};$af(0);$af(1)
+</script>
+<div
+  id="GENERATED-8"
+  style="display:none"
+/>
+<script>
+  $af(2)
+</script>
+<div
+  id="GENERATED-9"
+  style="display:none"
+>
+  next chunk for slot_1
+  <noscript
+    id="GENERATED-10"
+  />
+</div>
+<div
+  id="GENERATED-11"
+  style="display:none"
+>
+  next chunk for slot_2
+  <noscript
+    id="GENERATED-12"
+  />
+</div>
+<script>
+  $af(4);$af(5)
 </script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-stream-loading/renders.expected/loading.6.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-stream-loading/renders.expected/loading.6.html
@@ -17,6 +17,7 @@
   <p>
     test_html for slot_1
   </p>
+  next chunk for slot_1
   <noscript
     id="GENERATED-3"
   />
@@ -26,11 +27,13 @@
   data-slot="slot_2"
   id="GENERATED-4"
 >
-  <span
+  <p>
+    test_html for slot_2
+  </p>
+  next chunk for slot_2
+  <noscript
     id="GENERATED-5"
-  >
-    Loading...
-  </span>
+  />
 </div>
 <div
   id="GENERATED-6"
@@ -42,4 +45,22 @@
 />
 <script>
   function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b&lt;f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b&lt;f;b++)c(a[b])}};$af(0);$af(1)
+</script>
+<div
+  id="GENERATED-8"
+  style="display:none"
+/>
+<script>
+  $af(2)
+</script>
+<div
+  id="GENERATED-9"
+  style="display:none"
+/>
+<div
+  id="GENERATED-10"
+  style="display:none"
+/>
+<script>
+  $af(4);$af(5)
 </script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-stream-loading/renders.expected/loading.7.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-stream-loading/renders.expected/loading.7.html
@@ -17,6 +17,7 @@
   <p>
     test_html for slot_1
   </p>
+  next chunk for slot_1
   <noscript
     id="GENERATED-3"
   />
@@ -26,11 +27,13 @@
   data-slot="slot_2"
   id="GENERATED-4"
 >
-  <span
+  <p>
+    test_html for slot_2
+  </p>
+  next chunk for slot_2
+  <noscript
     id="GENERATED-5"
-  >
-    Loading...
-  </span>
+  />
 </div>
 <div
   id="GENERATED-6"
@@ -42,4 +45,37 @@
 />
 <script>
   function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b&lt;f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b&lt;f;b++)c(a[b])}};$af(0);$af(1)
+</script>
+<div
+  id="GENERATED-8"
+  style="display:none"
+/>
+<script>
+  $af(2)
+</script>
+<div
+  id="GENERATED-9"
+  style="display:none"
+/>
+<div
+  id="GENERATED-10"
+  style="display:none"
+/>
+<script>
+  $af(4);$af(5)
+</script>
+<div
+  id="GENERATED-11"
+  style="display:none"
+/>
+<div
+  id="GENERATED-12"
+  style="display:none"
+/>
+<div
+  id="GENERATED-13"
+  style="display:none"
+/>
+<script>
+  $af(3);$af(6);$af(7)
 </script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-stream-loading/renders.expected/loading.8.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/ssr-stream-loading/renders.expected/loading.8.html
@@ -1,0 +1,71 @@
+<div>
+  Host app
+</div>
+<div
+  data-src="embed"
+  id="GENERATED-0"
+/>
+<div
+  data-from="test"
+  data-slot="slot_1"
+  id="GENERATED-1"
+>
+  <p>
+    test_html for slot_1
+  </p>
+  next chunk for slot_1
+</div>
+<div
+  data-from="test"
+  data-slot="slot_2"
+  id="GENERATED-2"
+>
+  <p>
+    test_html for slot_2
+  </p>
+  next chunk for slot_2
+</div>
+<div
+  id="GENERATED-3"
+  style="display:none"
+/>
+<div
+  id="GENERATED-4"
+  style="display:none"
+/>
+<script>
+  function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b&lt;f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b&lt;f;b++)c(a[b])}};$af(0);$af(1)
+</script>
+<div
+  id="GENERATED-5"
+  style="display:none"
+/>
+<script>
+  $af(2)
+</script>
+<div
+  id="GENERATED-6"
+  style="display:none"
+/>
+<div
+  id="GENERATED-7"
+  style="display:none"
+/>
+<script>
+  $af(4);$af(5)
+</script>
+<div
+  id="GENERATED-8"
+  style="display:none"
+/>
+<div
+  id="GENERATED-9"
+  style="display:none"
+/>
+<div
+  id="GENERATED-10"
+  style="display:none"
+/>
+<script>
+  $af(3);$af(6);$af(7)
+</script>

--- a/src/components/micro-frame-sse/__tests__/fixtures/ssr-reorder-after-first-chunk/embed.marko
+++ b/src/components/micro-frame-sse/__tests__/fixtures/ssr-reorder-after-first-chunk/embed.marko
@@ -1,0 +1,25 @@
+import { wait } from "../../../../../__tests__/queue";
+import fs from "fs";
+import path from "path";
+
+$ const slot_1_html = fs.readFileSync(path.resolve(__dirname ,'slot_1.html'), 'utf8');
+$ const slot_2_html = fs.readFileSync(path.resolve(__dirname ,'slot_2.html'), 'utf8');
+$ const first = `id: slot_1\ndata: ${slot_1_html.replace(/\r?\n/g, '')}\n\n`;
+$ const second = `id: slot_2\ndata: ${slot_2_html.replace(/\r?\n/g, '')}\n\n`;
+$ const third = `id: slot_1\ntype: update\ndata: next chunk for slot_1`;
+
+<await(wait())>
+  <@then>
+    $!{first}
+    <await(wait())>
+      <@then>
+        $!{second}
+        <await(wait())>
+          <@then>
+            $!{third}
+          </@then>
+        </await>
+      </@then>
+    </await>
+  </@then>
+</await>

--- a/src/components/micro-frame-sse/__tests__/fixtures/ssr-reorder-after-first-chunk/index.marko
+++ b/src/components/micro-frame-sse/__tests__/fixtures/ssr-reorder-after-first-chunk/index.marko
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Simple Example</title>
+  <esbuild-assets/>
+</head>
+<body>
+  <div>Host app</div>
+<micro-frame-sse src="embed" name="test" read=(e => [e.lastEventId, e.data]) />
+<micro-frame-slot from="test" slot="slot_1" client-reorder="after-first-chunk" />
+<micro-frame-slot from="test" slot="slot_2" client-reorder />
+<await(new Promise(res => setTimeout(() => res('non-reorder data'))))>
+  <@then|result|>
+    ${result}
+  </@then>
+</await>
+</body>
+</html>

--- a/src/components/micro-frame-sse/__tests__/fixtures/ssr-reorder-after-first-chunk/slot_1.html
+++ b/src/components/micro-frame-sse/__tests__/fixtures/ssr-reorder-after-first-chunk/slot_1.html
@@ -1,0 +1,1 @@
+<p>test_html for slot_1</p>

--- a/src/components/micro-frame-sse/__tests__/fixtures/ssr-reorder-after-first-chunk/slot_2.html
+++ b/src/components/micro-frame-sse/__tests__/fixtures/ssr-reorder-after-first-chunk/slot_2.html
@@ -1,0 +1,1 @@
+<p>test_html for slot_2</p>

--- a/src/components/micro-frame-sse/__tests__/fixtures/ssr-stream-loading/embed.marko
+++ b/src/components/micro-frame-sse/__tests__/fixtures/ssr-stream-loading/embed.marko
@@ -6,7 +6,7 @@ $ const slot_1_html = fs.readFileSync(path.resolve(__dirname ,'slot_1.html'), 'u
 $ const slot_2_html = fs.readFileSync(path.resolve(__dirname ,'slot_2.html'), 'utf8');
 $ const first = `id: slot_1\ndata: ${slot_1_html.replace(/\r?\n/g, '')}\n\n`;
 $ const second = `id: slot_2\ndata: ${slot_2_html.replace(/\r?\n/g, '')}\n\n`;
-$ const third = `id: slot_1\ndata: next chunk for slot_1\n\n`;
+$ const third = `id: slot_1\ndata: next chunk for slot_1\n\nid: slot_2\ndata: next chunk for slot_2\n\n`;
 
 <await(wait())>
   <@then>

--- a/src/components/micro-frame-sse/__tests__/fixtures/ssr-stream-loading/index.marko
+++ b/src/components/micro-frame-sse/__tests__/fixtures/ssr-stream-loading/index.marko
@@ -9,12 +9,12 @@
 <body>
   <div>Host app</div>
   <micro-frame-sse src="embed" name="test" read=(e => [e.lastEventId, e.data]) />
-  <micro-frame-slot from="test" slot="slot_1">
+  <micro-frame-slot from="test" slot="slot_1" client-reorder>
     <@loading>
       Loading...
     </@loading>
   </micro-frame-slot>
-  <micro-frame-slot from="test" slot="slot_2">
+  <micro-frame-slot from="test" slot="slot_2" client-reorder>
     <@loading>
       Loading...
     </@loading>

--- a/src/components/micro-frame-sse/__tests__/server.test.ts
+++ b/src/components/micro-frame-sse/__tests__/server.test.ts
@@ -197,6 +197,11 @@ describe("micro-frame-sse", () => {
   );
 
   describe(
+    "ssr reorder after first chunk",
+    fixture(path.join(__dirname, "fixtures/ssr-reorder-after-first-chunk"))
+  );
+
+  describe(
     "ssr timeout",
     fixture(path.join(__dirname, "fixtures/ssr-timeout"))
   );

--- a/src/node_modules/@internal/micro-frame-slot-component/node.marko
+++ b/src/node_modules/@internal/micro-frame-slot-component/node.marko
@@ -7,7 +7,7 @@ $ {
 <div id=component.id class=input.class style=input.style data-slot=input.slot data-from=input.from>
   <macro|{ loaded }| name="wait">
     <await(stream.next())
-      client-reorder=input.clientReorder
+      client-reorder=(input.clientReorder === "after-first-chunk" ? !!loaded : !!input.clientReorder)
       timeout=input.timeout
       placeholder=(loaded ? undefined : input.loading)
     >

--- a/src/node_modules/@internal/micro-frame-slot-component/node.marko
+++ b/src/node_modules/@internal/micro-frame-slot-component/node.marko
@@ -3,27 +3,21 @@ import { getSource } from "../../../util/stream";
 $ {
   const streamSource = getSource(input.from, out);
   const stream = streamSource.slot(input.slot);
-  let finishLoading;
-  const loadingPromise =
-    input.loading && new Promise((res) => (finishLoading = res));
 }
 <div id=component.id class=input.class style=input.style data-slot=input.slot data-from=input.from>
-  <macro name="wait">
+  <macro|{ loaded }| name="wait">
     <await(stream.next())
       client-reorder=input.clientReorder
       timeout=input.timeout
+      placeholder=(loaded ? undefined : input.loading)
     >
       <@then|{ value, done }|>
         <if(!done)>
           $!{value}
-          <wait/>
+          <wait loaded=true />
         </if>
-        <else>
-          $ finishLoading && finishLoading();
-        </else>
       </@then>
       <@catch|e|>
-        $ finishLoading && finishLoading();
         <script>document.getElementById(${JSON.stringify(component.id)}).textContent=""</script>
         <${input.catch}(e)/>
       </@catch>
@@ -31,9 +25,6 @@ $ {
   </macro>
   $ out.bf("@_", component, true);
   <if(stream)>
-    <if(input.loading)>
-      <await(loadingPromise) placeholder=input.loading client-reorder/>
-    </if>
     <wait/>
   </if>
   $ out.ef();

--- a/src/node_modules/@internal/micro-frame-slot-component/web.component.ts
+++ b/src/node_modules/@internal/micro-frame-slot-component/web.component.ts
@@ -85,6 +85,8 @@ export = {
       // eslint-disable-next-line no-constant-condition
       while (true) {
         const { value, done } = await this.slot.next();
+        // finished loading after first
+        this.state.loading = false;
         if (done) break;
         writable.write(value);
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail.  Include the package name if applicable. -->

1. First thing is to show loading indicator only before stream starts. I feel it doesn't make sense to still show loading indicator while content are populating.
2. Second is a feature that allows `ebay-ads-slot` tag to be rendered in-order before first chunk then convert to out-of-order afterwards. In the case that the loading shimmer is sent from the stream (as first chunk), we want the slot to hold the order until shimmer is ready. If the tag is out-of-order, there is always a content shift even if the first chunk is cached and streamed at very beginning.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
