### PR TITLE
fix: client side stream source lookup issue

### DIFF
--- a/src/node_modules/@internal/micro-frame-slot-component/web.component.ts
+++ b/src/node_modules/@internal/micro-frame-slot-component/web.component.ts
@@ -13,6 +13,7 @@ interface Input {
   loading?: unknown;
   cache?: RequestCache;
   headers?: Record<string, string>;
+  noRefresh?: boolean;
 }
 
 interface State {
@@ -36,7 +37,7 @@ export = {
 
     this.handleSrcChange = this.handleSrcChange.bind(this);
   },
-  onInput(input) {
+  onInput(input: Input) {
     if (this.from !== input.from) {
       this.from = input.from;
       this.streamSource = getSource(input.from);
@@ -107,10 +108,11 @@ export = {
   curSrc: string | undefined;
   slot: StreamWritable | undefined;
   streamSource: StreamSource;
-  onUpdate(): unknown;
-  onCreate(): unknown;
-  onMount(): unknown;
-  onDestroy(): unknown;
-  forceUpdate(): unknown;
-  handleSrcChange(src: string): unknown;
+  onInput(): any;
+  onUpdate(): any;
+  onCreate(): any;
+  onMount(): any;
+  onDestroy(): any;
+  forceUpdate(): any;
+  handleSrcChange(src: string): any;
 };

--- a/src/node_modules/@internal/stream-source-component/web.component.ts
+++ b/src/node_modules/@internal/stream-source-component/web.component.ts
@@ -41,7 +41,7 @@ export = {
       this.src = ssrEl.dataset.src;
     }
   },
-  onInput(input) {
+  onInput(input: Input) {
     this.streamSource = getSource(input.name);
   },
   onMount() {
@@ -86,8 +86,9 @@ export = {
   src: string | undefined;
   method: string | undefined;
   controller: AbortController | undefined;
-  onUpdate(): unknown;
-  onCreate(): unknown;
-  onMount(): unknown;
-  onDestroy(): unknown;
+  onInput(): any;
+  onUpdate(): any;
+  onCreate(): any;
+  onMount(): any;
+  onDestroy(): any;
 };

--- a/src/util/stream.ts
+++ b/src/util/stream.ts
@@ -1,4 +1,4 @@
-const kReadableByName = Symbol.for("stream-source");
+const kReadableByName = Symbol.for("micro-frame:stream-source");
 
 type InvalidateHandler = (newSrc: string) => void;
 interface DeferredPromise extends Promise<void> {

--- a/src/util/stream.ts
+++ b/src/util/stream.ts
@@ -1,4 +1,4 @@
-const kReadableByName = Symbol("stream-source");
+const kReadableByName = Symbol.for("stream-source");
 
 type InvalidateHandler = (newSrc: string) => void;
 interface DeferredPromise extends Promise<void> {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "src/node_modules/**/*"],
   "compilerOptions": {
     "lib": ["dom", "ESNext", "scripthost"],
     "strict": true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail.  Include the package name if applicable. -->

In client-side, if `<micro-frame-sse>` and `<micro-frame-slot>` are from different bundle, they will end up querying different `kReadableByName` if using `Symbol("stream-source")`. The solution is to use `Symbol.for("stream-source")`.

Also updated tsconfig to properly compile files under src/node_modules

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
