### PR TITLE
fix: avoid trailing comma in await for marko@4

### DIFF
--- a/src/node_modules/@internal/stream-source-component/node.marko
+++ b/src/node_modules/@internal/stream-source-component/node.marko
@@ -86,9 +86,8 @@ $ const streamSource = getSource(input.name, out);
   $ out.bf("@_", component, true);
   <await(request()) client-reorder timeout=input.timeout>
     <@then|{ body }|>
-      <await(
-        streamSource.run(input.parser(body[Symbol.asyncIterator]())),
-      ) client-reorder>
+      $ const iter = input.parser(body[Symbol.asyncIterator]());
+      <await(streamSource.run(iter)) client-reorder>
         <@catch|err|>
           $ streamSource.close(err);
         </@catch>


### PR DESCRIPTION
## Description

Avoids using trailing comma in `<await>` arguments which isn't supported in Marko 4.
