### PR TITLE
fix: avoid using macro tag

### DIFF
--- a/src/components/micro-frame/__tests__/__snapshots__/ssr-then-csr-with-flush/renders.expected/loading.0.html
+++ b/src/components/micro-frame/__tests__/__snapshots__/ssr-then-csr-with-flush/renders.expected/loading.0.html
@@ -1,0 +1,10 @@
+<div>
+  Host app
+</div>
+<div>
+  mounted: false
+</div>
+<div
+  data-src="embed"
+  id="GENERATED-0"
+/>

--- a/src/components/micro-frame/__tests__/__snapshots__/ssr-then-csr-with-flush/renders.expected/loading.1.html
+++ b/src/components/micro-frame/__tests__/__snapshots__/ssr-then-csr-with-flush/renders.expected/loading.1.html
@@ -1,0 +1,12 @@
+<div>
+  Host app
+</div>
+<div>
+  mounted: false
+</div>
+<div
+  data-src="embed"
+  id="GENERATED-0"
+>
+  <div />
+</div>

--- a/src/components/micro-frame/__tests__/__snapshots__/ssr-then-csr-with-flush/renders.expected/loading.2.html
+++ b/src/components/micro-frame/__tests__/__snapshots__/ssr-then-csr-with-flush/renders.expected/loading.2.html
@@ -1,0 +1,16 @@
+<div>
+  Host app
+</div>
+<div>
+  mounted: false
+</div>
+<div
+  data-src="embed"
+  id="GENERATED-0"
+>
+  <div>
+    <div
+      hacks=""
+    />
+  </div>
+</div>

--- a/src/components/micro-frame/__tests__/__snapshots__/ssr-then-csr-with-flush/renders.expected/loading.3.html
+++ b/src/components/micro-frame/__tests__/__snapshots__/ssr-then-csr-with-flush/renders.expected/loading.3.html
@@ -1,0 +1,19 @@
+<div>
+  Host app
+</div>
+<div>
+  mounted: false
+</div>
+<div
+  data-src="embed"
+  id="GENERATED-0"
+>
+  <div>
+    <div
+      hacks=""
+    />
+  </div>
+</div>
+<script>
+  $ssr_then_csr_with_flush_index_C=(window.$ssr_then_csr_with_flush_index_C||[]).concat({"l":1,"w":[["s0-8",0,{},{"f":1}]],"t":["o4cI23nl"]})
+</script>

--- a/src/components/micro-frame/__tests__/__snapshots__/ssr-then-csr-with-flush/renders.expected/loading.4.html
+++ b/src/components/micro-frame/__tests__/__snapshots__/ssr-then-csr-with-flush/renders.expected/loading.4.html
@@ -1,0 +1,16 @@
+<div>
+  Host app
+</div>
+<div>
+  mounted: false
+</div>
+<div>
+  <div>
+    <div
+      hacks=""
+    />
+  </div>
+</div>
+<script>
+  $ssr_then_csr_with_flush_index_C=(window.$ssr_then_csr_with_flush_index_C||[]).concat({"l":1,"w":[["s0-8",0,{},{"f":1}]],"t":["o4cI23nl"]})
+</script>

--- a/src/components/micro-frame/__tests__/__snapshots__/ssr-then-csr-with-flush/renders.expected/loading.5.html
+++ b/src/components/micro-frame/__tests__/__snapshots__/ssr-then-csr-with-flush/renders.expected/loading.5.html
@@ -1,0 +1,16 @@
+<div>
+  Host app
+</div>
+<div>
+  mounted: true
+</div>
+<div>
+  <div>
+    <div
+      hacks=""
+    />
+  </div>
+</div>
+<script>
+  $ssr_then_csr_with_flush_index_C=(window.$ssr_then_csr_with_flush_index_C||[]).concat({"l":1,"w":[["s0-8",0,{},{"f":1}]],"t":["o4cI23nl"]})
+</script>

--- a/src/components/micro-frame/__tests__/fixtures/ssr-then-csr-with-flush/components/app.marko
+++ b/src/components/micro-frame/__tests__/fixtures/ssr-then-csr-with-flush/components/app.marko
@@ -1,0 +1,11 @@
+class {
+  onCreate() {
+    this.state = { mounted: false };
+  }
+  onMount() {
+    this.state.mounted = true;
+  }
+}
+
+<div>mounted: ${state.mounted}</div>
+<micro-frame src="embed"/>

--- a/src/components/micro-frame/__tests__/fixtures/ssr-then-csr-with-flush/embed.marko
+++ b/src/components/micro-frame/__tests__/fixtures/ssr-then-csr-with-flush/embed.marko
@@ -1,0 +1,9 @@
+<esbuild-assets/>
+<div>
+  $ out.write("<div ");
+  <await(new Promise((res) => setTimeout(res)))>
+    <@then>hacks</@then>
+  </>
+
+  $ out.write("></div>");
+</div>

--- a/src/components/micro-frame/__tests__/fixtures/ssr-then-csr-with-flush/index.marko
+++ b/src/components/micro-frame/__tests__/fixtures/ssr-then-csr-with-flush/index.marko
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Simple Example</title>
+  <esbuild-assets/>
+</head>
+<body>
+  <div>Host app</div>
+  <app/>
+</body>
+</html>

--- a/src/components/micro-frame/__tests__/server.test.ts
+++ b/src/components/micro-frame/__tests__/server.test.ts
@@ -13,6 +13,11 @@ describe(
 );
 
 describe(
+  "ssr then csr with flush",
+  fixture(path.join(__dirname, "fixtures/ssr-then-csr-with-flush"))
+);
+
+describe(
   "csr stream text",
   fixture(path.join(__dirname, "fixtures/csr-stream-text"))
 );

--- a/src/node_modules/@internal/micro-frame-component/components/ssr-wait.marko
+++ b/src/node_modules/@internal/micro-frame-component/components/ssr-wait.marko
@@ -1,0 +1,26 @@
+<await(input.iter.next()) timeout=input.timeout>
+  <@then|{ value, done }|>
+    <if(done)>
+      <if(input.loading)>
+        <!-- Remove all of the <@loading> content after we've received all the data -->
+        $ out.script(
+          `((e,t,d)=>{t=document.getElementById(e);do{t.removeChild(d=t.firstChild)}while(d.data!==e)})(${JSON.stringify(input.id)});`,
+        );
+      </if>
+    </if>
+    <else>
+      $!{value}
+      <ssr-wait ...input/>
+    </else>
+  </@then>
+  <@catch|err|>
+    <if(input.catch)>
+      <!-- Remove everything in the container and render our catch handler -->
+      $ out.write(`<script>(function(e){if(e)e.textContent=""})(document.getElementById(${JSON.stringify(input.id)}))</script>`);
+      <${input.catch}(err)/>
+    </if>
+    <else>
+      $ throw err;
+    </else>
+  </@catch>
+</await>

--- a/src/node_modules/@internal/micro-frame-component/node.marko
+++ b/src/node_modules/@internal/micro-frame-component/node.marko
@@ -98,36 +98,13 @@ static async function fetchStream(input, out) {
   $ out.bf("@_", component, true);
   <await(fetchStream(input, out)) timeout=input.timeout catch=input.catch>
     <@then|iter|>
-      <macro name="wait">
-        <await(iter.next()) timeout=input.timeout>
-          <@then|{ value, done }|>
-            <if(done)>
-              <if(input.loading)>
-                <!-- Remove all of the <@loading> content after we've received all the data -->
-                $ out.script(
-                  `((e,t,d)=>{t=document.getElementById(e);do{t.removeChild(d=t.firstChild)}while(d.data!==e)})(${JSON.stringify(component.id)});`,
-                );
-              </if>
-            </if>
-            <else>
-              $!{value}
-              <wait/>
-            </else>
-          </@then>
-          <@catch|err|>
-            <if(input.catch)>
-              <!-- Remove everything in the container and render our catch handler -->
-              <script>(function(e){if(e)e.textContent=""})(document.getElementById(${JSON.stringify(component.id)}))</script>
-              <${input.catch}(err)/>
-            </if>
-            <else>
-              $ throw err;
-            </else>
-          </@catch>
-        </await>
-      </macro>
-
-      <wait/>
+      <ssr-wait
+        id=component.id
+        iter=iter
+        timeout=input.timeout
+        loading=input.loading
+        catch=input.catch
+      />
     </@then>
   </await>
   $ out.ef();

--- a/src/node_modules/@internal/micro-frame-slot-component/components/ssr-wait.marko
+++ b/src/node_modules/@internal/micro-frame-slot-component/components/ssr-wait.marko
@@ -1,0 +1,23 @@
+<await(input.iter.next())
+  client-reorder=(
+    input.clientReorder === "after-first-chunk"
+      ? !!input.loaded
+      : !!input.clientReorder
+  )
+  timeout=input.timeout
+>
+  <@then|{ value, done }|>
+    <if(!done)>
+      $!{value}
+      <ssr-wait ...input loaded/>
+    </if>
+    <else>
+      $ input.finishLoading();
+    </else>
+  </@then>
+  <@catch|e|>
+    $ input.finishLoading();
+    $ out.write(`<script>(function(e){if(e)e.textContent=""})(document.getElementById(${JSON.stringify(input.id)}))</script>`);
+    <${input.catch}(e)/>
+  </@catch>
+</await>

--- a/src/node_modules/@internal/micro-frame-slot-component/node.marko
+++ b/src/node_modules/@internal/micro-frame-slot-component/node.marko
@@ -1,40 +1,35 @@
 import { getSource } from "../../../util/stream";
-
-$ {
-  const streamSource = getSource(input.from, out);
-  const stream = streamSource.slot(input.slot);
-  let finishLoading;
-  const loadingPromise =
-    input.loading && new Promise((res) => (finishLoading = res));
-}
-<div id=component.id class=input.class style=input.style data-slot=input.slot data-from=input.from>
-  <macro|{ loaded }| name="wait">
-    <await(stream.next())
-      client-reorder=(input.clientReorder === "after-first-chunk" ? !!loaded : !!input.clientReorder)
-      timeout=input.timeout
-    >
-      <@then|{ value, done }|>
-        <if(!done)>
-          $!{value}
-          <wait loaded=true />
-        </if>
-        <else>
-          $ finishLoading && finishLoading();
-        </else>
-      </@then>
-      <@catch|e|>
-        $ finishLoading && finishLoading();
-        <script>(function(e){if(e)e.textContent=""})(document.getElementById(${JSON.stringify(component.id)}))</script>
-        <${input.catch}(e)/>
-      </@catch>
-    </await>
-  </macro>
+$ const streamSource = getSource(input.from, out);
+$ const stream = streamSource.slot(input.slot);
+$ let finishLoading;
+$ const loadingPromise = (
+  input.loading && new Promise((res) => (finishLoading = res))
+);
+<div
+  id=component.id
+  class=input.class
+  style=input.style
+  data-slot=input.slot
+  data-from=input.from
+>
   $ out.bf("@_", component, true);
   <if(stream)>
     <if(input.loading)>
-      <await(loadingPromise) placeholder=input.loading client-reorder/>
+      <await(loadingPromise)
+        timeout=input.timeout
+        placeholder=input.loading
+        client-reorder
+      />
     </if>
-    <wait/>
+    <ssr-wait
+      id=component.id
+      iter=stream
+      timeout=input.timeout
+      clientReorder=input.clientReorder
+      finishLoading=(() => finishLoading && finishLoading())
+      loaded=false
+      catch=input.catch
+    />
   </if>
   $ out.ef();
 </div>


### PR DESCRIPTION
## Description

Using the `<macro>` tag recursively while inserting arbitrary html from the micro-frame could cause comments to be inserted in between flushes from the micro-frame if the micro-frame itself was client rendered.

This PR switches the implementation to use a recursive tag instead of a macro which shouldn't have this issue.
