### PR TITLE
fix: ignore error if stream is ended

### DIFF
--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/csr-slot-done-and-error/renders.expected/loading.0.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/csr-slot-done-and-error/renders.expected/loading.0.html
@@ -1,0 +1,9 @@
+<div>
+  Host app
+</div>
+<button>
+  Load Slot1
+</button>
+<script>
+  $csr_slot_done_and_error_index_C=(window.$csr_slot_done_and_error_index_C||[]).concat({"l":1,"w":[["s0-8",0,{},{"f":1}]],"t":["BQ+bMDNF"]})
+</script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/csr-slot-done-and-error/renders.expected/loading.1.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/csr-slot-done-and-error/renders.expected/loading.1.html
@@ -1,0 +1,13 @@
+<div>
+  Host app
+</div>
+<button>
+  Load Slot1
+</button>
+<div />
+<div>
+  Loading...
+</div>
+<script>
+  $csr_slot_done_and_error_index_C=(window.$csr_slot_done_and_error_index_C||[]).concat({"l":1,"w":[["s0-8",0,{},{"f":1}]],"t":["BQ+bMDNF"]})
+</script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/csr-slot-done-and-error/renders.expected/loading.2.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/csr-slot-done-and-error/renders.expected/loading.2.html
@@ -1,0 +1,16 @@
+<div>
+  Host app
+</div>
+<button>
+  Load Slot1
+</button>
+<div />
+<div>
+  Loading...
+  <p>
+    test_html for slot_2
+  </p>
+</div>
+<script>
+  $csr_slot_done_and_error_index_C=(window.$csr_slot_done_and_error_index_C||[]).concat({"l":1,"w":[["s0-8",0,{},{"f":1}]],"t":["BQ+bMDNF"]})
+</script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/csr-slot-done-and-error/renders.expected/loading.3.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/csr-slot-done-and-error/renders.expected/loading.3.html
@@ -1,0 +1,15 @@
+<div>
+  Host app
+</div>
+<button>
+  Load Slot1
+</button>
+<div />
+<div>
+  <p>
+    test_html for slot_2
+  </p>
+</div>
+<script>
+  $csr_slot_done_and_error_index_C=(window.$csr_slot_done_and_error_index_C||[]).concat({"l":1,"w":[["s0-8",0,{},{"f":1}]],"t":["BQ+bMDNF"]})
+</script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/csr-slot-done-and-error/renders.expected/step-0.0.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/csr-slot-done-and-error/renders.expected/step-0.0.html
@@ -1,0 +1,18 @@
+<div>
+  Host app
+</div>
+<button>
+  Load Slot1
+</button>
+<div />
+<div>
+  <p>
+    test_html for slot_2
+  </p>
+</div>
+<div>
+  Loading...
+</div>
+<script>
+  $csr_slot_done_and_error_index_C=(window.$csr_slot_done_and_error_index_C||[]).concat({"l":1,"w":[["s0-8",0,{},{"f":1}]],"t":["BQ+bMDNF"]})
+</script>

--- a/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/csr-slot-done-and-error/renders.expected/step-0.1.html
+++ b/src/components/micro-frame-sse/__tests__/__snapshots__/micro-frame-sse/csr-slot-done-and-error/renders.expected/step-0.1.html
@@ -1,0 +1,20 @@
+<div>
+  Host app
+</div>
+<button>
+  Load Slot1
+</button>
+<div />
+<div>
+  <p>
+    test_html for slot_2
+  </p>
+</div>
+<div>
+  <p>
+    test_html for slot_1
+  </p>
+</div>
+<script>
+  $csr_slot_done_and_error_index_C=(window.$csr_slot_done_and_error_index_C||[]).concat({"l":1,"w":[["s0-8",0,{},{"f":1}]],"t":["BQ+bMDNF"]})
+</script>

--- a/src/components/micro-frame-sse/__tests__/fixtures/csr-slot-done-and-error/components/app.marko
+++ b/src/components/micro-frame-sse/__tests__/fixtures/csr-slot-done-and-error/components/app.marko
@@ -12,7 +12,7 @@ class {
 
 <button onClick("loadSlot1")>Load Slot1</button>
 <if(state.mounted)>
-  <micro-frame-sse src="embed" name="test" read(e) { return [e.lastEventId, e.data, true] } />
+  <micro-frame-sse src="embed" name="test" read(e) { if (e.data === "error") { throw new Error("error"); } else { return [e.lastEventId, e.data, true] } } />
   <micro-frame-slot from="test" slot="slot_2">
     <@loading>
       Loading...

--- a/src/components/micro-frame-sse/__tests__/fixtures/csr-slot-done-and-error/components/app.marko
+++ b/src/components/micro-frame-sse/__tests__/fixtures/csr-slot-done-and-error/components/app.marko
@@ -1,0 +1,31 @@
+class {
+  onCreate() {
+    this.state = { mounted: false, loadSlot1: false };
+  }
+  onMount() {
+    this.state.mounted = true;
+  }
+  loadSlot1() {
+    this.state.loadSlot1 = true;
+  }
+}
+
+<button onClick("loadSlot1")>Load Slot1</button>
+<if(state.mounted)>
+  <micro-frame-sse src="embed" name="test" read(e) { return [e.lastEventId, e.data, true] } />
+  <micro-frame-slot from="test" slot="slot_2">
+    <@loading>
+      Loading...
+    </@loading>
+  </micro-frame-slot>
+  <if(state.loadSlot1)>
+    <micro-frame-slot from="test" slot="slot_1">
+      <@loading>
+        Loading...
+      </@loading>
+      <@catch|err|>
+        ${err}
+      </@catch>
+    </micro-frame-slot>
+  </if>
+</if>

--- a/src/components/micro-frame-sse/__tests__/fixtures/csr-slot-done-and-error/embed.marko
+++ b/src/components/micro-frame-sse/__tests__/fixtures/csr-slot-done-and-error/embed.marko
@@ -1,0 +1,26 @@
+import { wait } from "../../../../../__tests__/queue";
+import fs from "fs";
+import path from "path";
+
+$ const slot_1_html = fs.readFileSync(path.resolve(__dirname ,'slot_1.html'), 'utf8');
+$ const slot_2_html = fs.readFileSync(path.resolve(__dirname ,'slot_2.html'), 'utf8');
+$ const first = `id: slot_1\ndata: ${slot_1_html.replace(/\r?\n/g, '')}\n\n`;
+$ const second = `id: slot_2\ndata: ${slot_2_html.replace(/\r?\n/g, '')}\n\n`;
+$ const third = `id: slot_1\ndata: next chunk for slot_1\n\n`;
+
+<await(wait())>
+  <@then>
+    $!{first}
+    <await(wait())>
+      <@then>
+        $!{second}
+        <await(wait())>
+          <@then>
+            $!{third}
+            <await(new Promise((_, reject) => setTimeout(() => reject("Error"), 100))) />
+          </@then>
+        </await>
+      </@then>
+    </await>
+  </@then>
+</await>

--- a/src/components/micro-frame-sse/__tests__/fixtures/csr-slot-done-and-error/embed.marko
+++ b/src/components/micro-frame-sse/__tests__/fixtures/csr-slot-done-and-error/embed.marko
@@ -6,7 +6,7 @@ $ const slot_1_html = fs.readFileSync(path.resolve(__dirname ,'slot_1.html'), 'u
 $ const slot_2_html = fs.readFileSync(path.resolve(__dirname ,'slot_2.html'), 'utf8');
 $ const first = `id: slot_1\ndata: ${slot_1_html.replace(/\r?\n/g, '')}\n\n`;
 $ const second = `id: slot_2\ndata: ${slot_2_html.replace(/\r?\n/g, '')}\n\n`;
-$ const third = `id: slot_1\ndata: next chunk for slot_1\n\n`;
+$ const third = `id: slot_1\ndata: error\n\n`;
 
 <await(wait())>
   <@then>
@@ -17,7 +17,6 @@ $ const third = `id: slot_1\ndata: next chunk for slot_1\n\n`;
         <await(wait())>
           <@then>
             $!{third}
-            <await(new Promise((_, reject) => setTimeout(() => reject("Error"), 100))) />
           </@then>
         </await>
       </@then>

--- a/src/components/micro-frame-sse/__tests__/fixtures/csr-slot-done-and-error/index.marko
+++ b/src/components/micro-frame-sse/__tests__/fixtures/csr-slot-done-and-error/index.marko
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Simple Example</title>
+  <esbuild-assets/>
+</head>
+<body>
+  <div>Host app</div>
+  <app/>
+</body>
+</html>

--- a/src/components/micro-frame-sse/__tests__/fixtures/csr-slot-done-and-error/slot_1.html
+++ b/src/components/micro-frame-sse/__tests__/fixtures/csr-slot-done-and-error/slot_1.html
@@ -1,0 +1,1 @@
+<p>test_html for slot_1</p>

--- a/src/components/micro-frame-sse/__tests__/fixtures/csr-slot-done-and-error/slot_2.html
+++ b/src/components/micro-frame-sse/__tests__/fixtures/csr-slot-done-and-error/slot_2.html
@@ -1,0 +1,1 @@
+<p>test_html for slot_2</p>

--- a/src/components/micro-frame-sse/__tests__/server.test.ts
+++ b/src/components/micro-frame-sse/__tests__/server.test.ts
@@ -171,6 +171,13 @@ describe("micro-frame-sse", () => {
     fixture(path.join(__dirname, "fixtures/csr-slot-done-signal"))
   );
 
+  describe(
+    "csr slot done and error",
+    fixture(path.join(__dirname, "fixtures/csr-slot-done-and-error"), [
+      async (page) => await page.click("text=Load Slot1"),
+    ])
+  );
+
   describe("csr 404", fixture(path.join(__dirname, "fixtures/csr-404")));
 
   describe("ssr 404", fixture(path.join(__dirname, "fixtures/ssr-404")));

--- a/src/util/stream.ts
+++ b/src/util/stream.ts
@@ -113,7 +113,6 @@ export function createWritable(): StreamWritable {
     },
     error(reason: unknown) {
       error = reason;
-      done = true;
       buf = "";
 
       if (pending) {
@@ -122,10 +121,6 @@ export function createWritable(): StreamWritable {
       }
     },
     async next() {
-      if (error) {
-        throw error;
-      }
-
       if (buf) {
         const value = buf;
         buf = "";
@@ -140,6 +135,10 @@ export function createWritable(): StreamWritable {
           value: undefined,
           done: true,
         };
+      }
+
+      if (error) {
+        throw error;
       }
 
       await (pending = createDeferred());

--- a/src/util/stream.ts
+++ b/src/util/stream.ts
@@ -113,7 +113,6 @@ export function createWritable(): StreamWritable {
     },
     error(reason: unknown) {
       error = reason;
-      buf = "";
 
       if (pending) {
         pending.reject(reason);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail.  Include the package name if applicable. -->

Currently, if one is doing `slot.end() && slow.error()` the slot will be collapsed. This fix makes sure that `slot.end()` will have higher priority than `error()`;

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
